### PR TITLE
Batch token balance requests

### DIFF
--- a/src/containers/HubiiApiHoc/reducer.js
+++ b/src/containers/HubiiApiHoc/reducer.js
@@ -18,6 +18,7 @@ import {
   LOAD_TRANSACTIONS_SUCCESS,
   LOAD_TRANSACTIONS_ERROR,
 } from './constants';
+import { ADD_NEW_WALLET } from '../WalletHoc/constants';
 
 export const initialState = fromJS({
   transactions: {},
@@ -85,6 +86,9 @@ function hubiiApiHocReducer(state = initialState, action) {
         .setIn(['prices', 'loading'], true)
         .set('transactions', fromJS({}))
         .set('balances', fromJS({}));
+    case ADD_NEW_WALLET:
+      return state
+        .setIn(['balances', action.newWallet.address], fromJS({ loading: true, error: null, assets: [] }));
     default:
       return state;
   }

--- a/src/containers/HubiiApiHoc/saga.js
+++ b/src/containers/HubiiApiHoc/saga.js
@@ -107,8 +107,8 @@ export function* loadWalletBalances({ address, noPoll, onlyEth }, _network) {
     } catch (err) {
       yield put(loadWalletBalancesError(address, err));
     } finally {
-      const TEN_SEC_IN_MS = 1000 * 10;
-      yield delay(TEN_SEC_IN_MS);
+      const TWENTY_SEC_IN_MS = 1000 * 20;
+      yield delay(TWENTY_SEC_IN_MS);
     }
     if (noPoll) break;
   }

--- a/src/containers/HubiiApiHoc/tests/reducer.test.js
+++ b/src/containers/HubiiApiHoc/tests/reducer.test.js
@@ -25,6 +25,7 @@ import {
 
 
 import hubiiApiHocReducer from '../reducer';
+import { addNewWallet } from '../../WalletHoc/actions';
 
 describe('hubiiApiHocReducer', () => {
   let state;
@@ -178,6 +179,18 @@ describe('hubiiApiHocReducer', () => {
         .set('balances', fromJS({}));
 
       expect(hubiiApiHocReducer(testState, changeNetwork('some network'))).toEqual(expected);
+    });
+  });
+
+  describe('a wallet is added', () => {
+    it('should reset its balance to loading state', () => {
+      const newWalletAddr = '0x00';
+      const testState = state
+        .setIn(['balances', newWalletAddr], fromJS({ assets: ['123'] }));
+      const expected = state
+        .setIn(['balances', newWalletAddr], fromJS({ loading: true, error: null, assets: [] }));
+
+      expect(hubiiApiHocReducer(testState, addNewWallet({ address: newWalletAddr }))).toEqual(expected);
     });
   });
 });

--- a/src/containers/WalletsOverview/index.js
+++ b/src/containers/WalletsOverview/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { createStructuredSelector } from 'reselect';
-import { Row, Col, Alert } from 'antd';
+import { Row, Col } from 'antd';
 import { injectIntl } from 'react-intl';
 
 import { getBreakdown } from 'utils/wallet';
@@ -113,15 +113,6 @@ export class WalletsOverview extends React.PureComponent { // eslint-disable-lin
             <Row type="flex" align="top" gutter={16}>
               {walletCards}
             </Row>
-            <Alert
-              message={formatMessage({ id: 'why_balance_not_updated' })}
-              description={
-                <span>{formatMessage({ id: 'my_balances_notes' })}</span>
-              }
-              type="info"
-              showIcon
-              style={{ margin: '2rem 0' }}
-            />
           </Col>
           <Col sm={24} md={12} lg={8}>
             {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -175,7 +175,5 @@
     "airdriip_registration_problem": "Sorry, something went wrong during registration: {message}",
     "airdriip_address_is_already_registered": "Address already registered, no further action is required",
     "airdriip_testnet_warning": "hubii core is currently connected to a nahmii test network. Registrations made on a test network will NOT qualify your wallet for the nahmii airdriip. To register for the real airdriip, you must connect hubii core to the mainnet by navigating to 'Settings', and changing the 'Network' option to 'Homestead [MAINNET]'.",
-    "warning": "Warning",
-    "why_balance_not_updated": "Why isn't my balance up to date?",
-    "my_balances_notes": "In this alpha build of hubii core, balances may take a few minutes to update. The more wallets you have imported, the slower balance updates will be. Until we improve this, we recommend having less than 4 wallets imported at any one time. If you want to double check a balance, we recommend using Etherscan."
+    "warning": "Warning"
 }

--- a/src/translations/zh.json
+++ b/src/translations/zh.json
@@ -175,7 +175,5 @@
     "airdriip_registration_problem": "抱歉，注册过程中发生错误：{message}",
     "airdriip_address_is_already_registered": "钱包地址已经被注册，无需进行更多操作",
     "airdriip_testnet_warning": "hubii core 当前连接的是 nahmii 测试网络。在测试网络的注册将无法获得 nahmii 空投。正确的注册方式，您应该在“设置”中连接到以太坊主网，选择“网络”选项为'Homestead [MAINNET]'。",
-    "warning": "警告",
-    "why_balance_not_updated": "为什么钱包余额没有同步?",
-    "my_balances_notes": "在此 alpha 版本中，可能需要几分钟的时间来同步钱包余额。钱包数量越多，需要同步的时间越长。 暂时，我们建议最多导入4个钱包。如果您想确认一下余额，我们建议使用 Etherscan。"
+    "warning": "警告"
 }

--- a/src/utils/rpcRequest.js
+++ b/src/utils/rpcRequest.js
@@ -1,0 +1,55 @@
+/**
+ * Modified version of the ethers.js providers.Provider.fetchJson, allowing batched RPC requests
+ */
+export default function (url, json) {
+  return new Promise((resolve, reject) => {
+    const request = new XMLHttpRequest();
+
+    if (json) {
+      request.open('POST', url, true);
+      request.setRequestHeader('Content-Type', 'application/json');
+    } else {
+      request.open('GET', url, true);
+    }
+
+    request.onreadystatechange = () => {
+      if (request.readyState !== 4) { return; }
+
+      let result;
+      try {
+        result = JSON.parse(request.responseText);
+      } catch (error) {
+        const jsonError = new Error('invalid json response');
+        jsonError.orginialError = error;
+        jsonError.responseText = request.responseText;
+        reject(jsonError);
+        return;
+      }
+
+      if (request.status !== 200) {
+        const error = new Error(`invalid response - ${request.status}`);
+        error.statusCode = request.statusCode;
+        reject(error);
+        return;
+      }
+
+      resolve(result);
+    };
+
+    request.onerror = (error) => {
+      reject(error);
+    };
+
+    try {
+      if (json) {
+        request.send(json);
+      } else {
+        request.send();
+      }
+    } catch (error) {
+      const connectionError = new Error('connection error');
+      connectionError.error = error;
+      reject(connectionError);
+    }
+  });
+}


### PR DESCRIPTION
- Batches token balance requests
- Sets a newly added wallet's balance to loading. The reasoning is that it may have an `ethOnly` balance before adding, and we want to wait until all it's balances have been fetched before showing the balances in the UI