### PR TITLE
1.1.0 beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
     "lodash.debounce": "^4.0.8",
     "minimist": "1.2.0",
     "moment": "2.22.2",
-    "nahmii-sdk": "2.2.4",
+    "nahmii-sdk": "2.2.5",
     "prop-types": "15.6.1",
     "qrcode.react": "0.8.0",
     "react": "16.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubii-core",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "author": {
     "name": "hubii",
     "email": "info@hubii.com",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prebuild": "node ./internals/scripts/pre-build.js",
     "build": "cross-env NODE_ENV=production webpack --config internals/webpack/webpack.prod.babel.js --color -p --progress --hide-modules --display-optimization-bailout && yarn electron-compile",
     "build:dll": "node ./internals/scripts/dependencies.js",
-    "start-web": "cross-env NODE_ENV=development NODE_OPTIONS=--max_old_space_size=4096 node server",
+    "start-web": "cross-env NODE_ENV=development NODE_OPTIONS=--max_old_space_size=2048 node server",
     "presetup": "npm i chalk shelljs",
     "setup": "node ./internals/scripts/setup.js",
     "postsetup": "npm run build:dll",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prebuild": "node ./internals/scripts/pre-build.js",
     "build": "cross-env NODE_ENV=production webpack --config internals/webpack/webpack.prod.babel.js --color -p --progress --hide-modules --display-optimization-bailout && yarn electron-compile",
     "build:dll": "node ./internals/scripts/dependencies.js",
-    "start-web": "cross-env NODE_ENV=development node server",
+    "start-web": "cross-env NODE_ENV=development NODE_OPTIONS=--max_old_space_size=4096 node server",
     "presetup": "npm i chalk shelljs",
     "setup": "node ./internals/scripts/setup.js",
     "postsetup": "npm run build:dll",

--- a/src/components/AirdriipRegistrationStatusUi/tests/__snapshots__/index.test.js.snap
+++ b/src/components/AirdriipRegistrationStatusUi/tests/__snapshots__/index.test.js.snap
@@ -8,6 +8,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     loading={true}
@@ -199,6 +200,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     loading={true}
@@ -389,6 +391,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     loading={true}

--- a/src/components/BreakdownList/index.js
+++ b/src/components/BreakdownList/index.js
@@ -37,7 +37,7 @@ const generateList = (data, formatMessage, extraInfo = false) => {
         {
         extraInfo &&
         <Percentage>
-          <StyledNumericText value={0} type="currency" />
+          <StyledNumericText value={0} type="fiat" />
         </Percentage>
       }
       </FlexItem>
@@ -62,7 +62,7 @@ const generateList = (data, formatMessage, extraInfo = false) => {
         <Percentage unknownPrice={unknownPrice}>
           { unknownPrice
             ? formatMessage({ id: 'missing_price' })
-            : <StyledText><StyledNumericText value={item.value} type="currency" /> {`(${item.percentage > 1 ? item.percentage.toFixed(0) : '<1'}%)`}</StyledText>
+            : <StyledText><StyledNumericText value={item.value} type="fiat" /> {`(${item.percentage > 1 ? item.percentage.toFixed(0) : '<1'}%)`}</StyledText>
           }
         </Percentage>
       }

--- a/src/components/BreakdownPie/index.js
+++ b/src/components/BreakdownPie/index.js
@@ -53,7 +53,7 @@ class Breakdown extends React.Component {
         <div>
           <Text large>{formatMessage({ id: 'total_fiat_value' })}</Text>
           <StyledHeading large>
-            <StyledNumericText large value={value.toString()} type="currency" />
+            <StyledNumericText large value={value.toString()} type="fiat" />
             {/* {formatFiat(value, 'USD')} */}
           </StyledHeading>
         </div>

--- a/src/components/BreakdownPie/tests/__snapshots__/index.test.js.snap
+++ b/src/components/BreakdownPie/tests/__snapshots__/index.test.js.snap
@@ -8,6 +8,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     supportedAssets={
@@ -252,6 +253,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     supportedAssets={
@@ -496,6 +498,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     supportedAssets={
@@ -722,6 +725,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     supportedAssets={
@@ -948,6 +952,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     supportedAssets={

--- a/src/components/BreakdownPie/tests/__snapshots__/index.test.js.snap
+++ b/src/components/BreakdownPie/tests/__snapshots__/index.test.js.snap
@@ -1136,7 +1136,7 @@ ShallowWrapper {
           >
                     <style__StyledNumericText
                               large={true}
-                              type="currency"
+                              type="fiat"
                               value="164.492044"
                     />
           </style__StyledHeading>
@@ -1190,7 +1190,7 @@ ShallowWrapper {
 >
               <style__StyledNumericText
                             large={true}
-                            type="currency"
+                            type="fiat"
                             value="164.492044"
               />
 </style__StyledHeading>,
@@ -1217,7 +1217,7 @@ ShallowWrapper {
             "props": Object {
               "children": <style__StyledNumericText
                 large={true}
-                type="currency"
+                type="fiat"
                 value="164.492044"
 />,
               "large": true,
@@ -1229,7 +1229,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "large": true,
-                "type": "currency",
+                "type": "fiat",
                 "value": "164.492044",
               },
               "ref": null,
@@ -1292,7 +1292,7 @@ ShallowWrapper {
             >
                         <style__StyledNumericText
                                     large={true}
-                                    type="currency"
+                                    type="fiat"
                                     value="164.492044"
                         />
             </style__StyledHeading>
@@ -1346,7 +1346,7 @@ ShallowWrapper {
 >
                 <style__StyledNumericText
                                 large={true}
-                                type="currency"
+                                type="fiat"
                                 value="164.492044"
                 />
 </style__StyledHeading>,
@@ -1373,7 +1373,7 @@ ShallowWrapper {
               "props": Object {
                 "children": <style__StyledNumericText
                   large={true}
-                  type="currency"
+                  type="fiat"
                   value="164.492044"
 />,
                 "large": true,
@@ -1385,7 +1385,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "large": true,
-                  "type": "currency",
+                  "type": "fiat",
                   "value": "164.492044",
                 },
                 "ref": null,

--- a/src/components/ContactList/tests/__snapshots__/index.test.js.snap
+++ b/src/components/ContactList/tests/__snapshots__/index.test.js.snap
@@ -21,6 +21,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     layout="horizontal"
@@ -518,6 +519,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     layout="horizontal"
@@ -980,6 +982,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     layout="horizontal"
@@ -1089,6 +1092,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     layout="horizontal"

--- a/src/components/DeletionModal/tests/__snapshots__/index.test.js.snap
+++ b/src/components/DeletionModal/tests/__snapshots__/index.test.js.snap
@@ -9,6 +9,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     name="mike"

--- a/src/components/HWPrompt/tests/__snapshots__/index.test.js.snap
+++ b/src/components/HWPrompt/tests/__snapshots__/index.test.js.snap
@@ -9,6 +9,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerInfo={
@@ -176,6 +177,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerInfo={
@@ -536,6 +538,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerInfo={
@@ -897,6 +900,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerInfo={
@@ -1258,6 +1262,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerInfo={
@@ -1425,6 +1430,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerInfo={

--- a/src/components/HomeScreen/tests/__snapshots__/index.test.js.snap
+++ b/src/components/HomeScreen/tests/__snapshots__/index.test.js.snap
@@ -8,6 +8,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
 />,

--- a/src/components/ImportWalletSteps/ImportWallet/tests/__snapshots__/index.test.js.snap
+++ b/src/components/ImportWalletSteps/ImportWallet/tests/__snapshots__/index.test.js.snap
@@ -8,6 +8,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     wallets={

--- a/src/components/SettlementTransaction/tests/__snapshots__/index.test.js.snap
+++ b/src/components/SettlementTransaction/tests/__snapshots__/index.test.js.snap
@@ -13,6 +13,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     onChange={[Function]}
@@ -301,6 +302,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     onChange={[Function]}
@@ -589,6 +591,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     onChange={[Function]}

--- a/src/components/Transaction/index.js
+++ b/src/components/Transaction/index.js
@@ -64,7 +64,7 @@ const Transaction = (props) => {
                 {type === 'received' ? formatMessage({ id: 'received' }) : formatMessage({ id: 'sent' })}
               </TypeText>
               <SelectableText>
-                <Amount value={amount.toString()} /> {symbol}
+                <Amount maxDecimalPlaces={18} value={amount.toString()} /> {symbol}
               </SelectableText>
               <FiatValue value={fiatEquivilent.toString()} type="currency"></FiatValue>
               <div style={{ marginLeft: 'auto' }}>

--- a/src/components/Transaction/index.js
+++ b/src/components/Transaction/index.js
@@ -66,7 +66,7 @@ const Transaction = (props) => {
               <SelectableText>
                 <Amount maxDecimalPlaces={18} value={amount.toString()} /> {symbol}
               </SelectableText>
-              <FiatValue value={fiatEquivilent.toString()} type="currency"></FiatValue>
+              <FiatValue value={fiatEquivilent.toString()} type="fiat"></FiatValue>
               <div style={{ marginLeft: 'auto' }}>
                 {
                   layer === 'nahmii' &&

--- a/src/components/Transaction/tests/__snapshots__/index.test.js.snap
+++ b/src/components/Transaction/tests/__snapshots__/index.test.js.snap
@@ -62,7 +62,7 @@ ShallowWrapper {
                                         UKG
                                 </SelectableText>
                                 <style__FiatValue
-                                        type="currency"
+                                        type="fiat"
                                         value="$123.34 USD"
                                 />
                                 <div
@@ -149,7 +149,7 @@ ShallowWrapper {
                                         UKG
                               </SelectableText>
                               <style__FiatValue
-                                        type="currency"
+                                        type="fiat"
                                         value="$123.34 USD"
                               />
                               <div
@@ -269,7 +269,7 @@ ShallowWrapper {
                         UKG
             </SelectableText>
             <style__FiatValue
-                        type="currency"
+                        type="fiat"
                         value="$123.34 USD"
             />
             <div
@@ -510,7 +510,7 @@ ShallowWrapper {
                                                   UKG
                                         </SelectableText>
                                         <style__FiatValue
-                                                  type="currency"
+                                                  type="fiat"
                                                   value="$123.34 USD"
                                         />
                                         <div
@@ -597,7 +597,7 @@ ShallowWrapper {
                                                 UKG
                                     </SelectableText>
                                     <style__FiatValue
-                                                type="currency"
+                                                type="fiat"
                                                 value="$123.34 USD"
                                     />
                                     <div
@@ -717,7 +717,7 @@ ShallowWrapper {
                             UKG
               </SelectableText>
               <style__FiatValue
-                            type="currency"
+                            type="fiat"
                             value="$123.34 USD"
               />
               <div
@@ -998,7 +998,7 @@ ShallowWrapper {
                                         UKG
                                 </SelectableText>
                                 <style__FiatValue
-                                        type="currency"
+                                        type="fiat"
                                         value="$123.34 USD"
                                 />
                                 <div
@@ -1087,7 +1087,7 @@ ShallowWrapper {
                                         UKG
                               </SelectableText>
                               <style__FiatValue
-                                        type="currency"
+                                        type="fiat"
                                         value="$123.34 USD"
                               />
                               <div
@@ -1211,7 +1211,7 @@ ShallowWrapper {
                         UKG
             </SelectableText>
             <style__FiatValue
-                        type="currency"
+                        type="fiat"
                         value="$123.34 USD"
             />
             <div
@@ -1456,7 +1456,7 @@ ShallowWrapper {
                                                   UKG
                                         </SelectableText>
                                         <style__FiatValue
-                                                  type="currency"
+                                                  type="fiat"
                                                   value="$123.34 USD"
                                         />
                                         <div
@@ -1545,7 +1545,7 @@ ShallowWrapper {
                                                 UKG
                                     </SelectableText>
                                     <style__FiatValue
-                                                type="currency"
+                                                type="fiat"
                                                 value="$123.34 USD"
                                     />
                                     <div
@@ -1669,7 +1669,7 @@ ShallowWrapper {
                             UKG
               </SelectableText>
               <style__FiatValue
-                            type="currency"
+                            type="fiat"
                             value="$123.34 USD"
               />
               <div
@@ -1954,7 +1954,7 @@ ShallowWrapper {
                                         UKG
                                 </SelectableText>
                                 <style__FiatValue
-                                        type="currency"
+                                        type="fiat"
                                         value="$123.34 USD"
                                 />
                                 <div
@@ -2043,7 +2043,7 @@ ShallowWrapper {
                                         UKG
                               </SelectableText>
                               <style__FiatValue
-                                        type="currency"
+                                        type="fiat"
                                         value="$123.34 USD"
                               />
                               <div
@@ -2167,7 +2167,7 @@ ShallowWrapper {
                         UKG
             </SelectableText>
             <style__FiatValue
-                        type="currency"
+                        type="fiat"
                         value="$123.34 USD"
             />
             <div
@@ -2412,7 +2412,7 @@ ShallowWrapper {
                                                   UKG
                                         </SelectableText>
                                         <style__FiatValue
-                                                  type="currency"
+                                                  type="fiat"
                                                   value="$123.34 USD"
                                         />
                                         <div
@@ -2501,7 +2501,7 @@ ShallowWrapper {
                                                 UKG
                                     </SelectableText>
                                     <style__FiatValue
-                                                type="currency"
+                                                type="fiat"
                                                 value="$123.34 USD"
                                     />
                                     <div
@@ -2625,7 +2625,7 @@ ShallowWrapper {
                             UKG
               </SelectableText>
               <style__FiatValue
-                            type="currency"
+                            type="fiat"
                             value="$123.34 USD"
               />
               <div
@@ -2910,7 +2910,7 @@ ShallowWrapper {
                                         UKG
                                 </SelectableText>
                                 <style__FiatValue
-                                        type="currency"
+                                        type="fiat"
                                         value="$123.34 USD"
                                 />
                                 <div
@@ -2999,7 +2999,7 @@ ShallowWrapper {
                                         UKG
                               </SelectableText>
                               <style__FiatValue
-                                        type="currency"
+                                        type="fiat"
                                         value="$123.34 USD"
                               />
                               <div
@@ -3123,7 +3123,7 @@ ShallowWrapper {
                         UKG
             </SelectableText>
             <style__FiatValue
-                        type="currency"
+                        type="fiat"
                         value="$123.34 USD"
             />
             <div
@@ -3368,7 +3368,7 @@ ShallowWrapper {
                                                   UKG
                                         </SelectableText>
                                         <style__FiatValue
-                                                  type="currency"
+                                                  type="fiat"
                                                   value="$123.34 USD"
                                         />
                                         <div
@@ -3457,7 +3457,7 @@ ShallowWrapper {
                                                 UKG
                                     </SelectableText>
                                     <style__FiatValue
-                                                type="currency"
+                                                type="fiat"
                                                 value="$123.34 USD"
                                     />
                                     <div
@@ -3581,7 +3581,7 @@ ShallowWrapper {
                             UKG
               </SelectableText>
               <style__FiatValue
-                            type="currency"
+                            type="fiat"
                             value="$123.34 USD"
               />
               <div

--- a/src/components/Transaction/tests/__snapshots__/index.test.js.snap
+++ b/src/components/Transaction/tests/__snapshots__/index.test.js.snap
@@ -13,6 +13,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     layer="baseLayer"
@@ -54,6 +55,7 @@ ShallowWrapper {
                                 </style__TypeText>
                                 <SelectableText>
                                         <style__Amount
+                                                maxDecimalPlaces={18}
                                                 value="0.000000000000000001"
                                         />
                                          
@@ -140,6 +142,7 @@ ShallowWrapper {
                               </style__TypeText>
                               <SelectableText>
                                         <style__Amount
+                                                  maxDecimalPlaces={18}
                                                   value="0.000000000000000001"
                                         />
                                          
@@ -259,6 +262,7 @@ ShallowWrapper {
             </style__TypeText>
             <SelectableText>
                         <style__Amount
+                                    maxDecimalPlaces={18}
                                     value="0.000000000000000001"
                         />
                          
@@ -499,6 +503,7 @@ ShallowWrapper {
                                         </style__TypeText>
                                         <SelectableText>
                                                   <style__Amount
+                                                            maxDecimalPlaces={18}
                                                             value="0.000000000000000001"
                                                   />
                                                    
@@ -585,6 +590,7 @@ ShallowWrapper {
                                     </style__TypeText>
                                     <SelectableText>
                                                 <style__Amount
+                                                            maxDecimalPlaces={18}
                                                             value="0.000000000000000001"
                                                 />
                                                  
@@ -704,6 +710,7 @@ ShallowWrapper {
               </style__TypeText>
               <SelectableText>
                             <style__Amount
+                                          maxDecimalPlaces={18}
                                           value="0.000000000000000001"
                             />
                              
@@ -942,6 +949,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     layer="baseLayer"
@@ -983,6 +991,7 @@ ShallowWrapper {
                                 </style__TypeText>
                                 <SelectableText>
                                         <style__Amount
+                                                maxDecimalPlaces={18}
                                                 value="0.000000000000000001"
                                         />
                                          
@@ -1071,6 +1080,7 @@ ShallowWrapper {
                               </style__TypeText>
                               <SelectableText>
                                         <style__Amount
+                                                  maxDecimalPlaces={18}
                                                   value="0.000000000000000001"
                                         />
                                          
@@ -1194,6 +1204,7 @@ ShallowWrapper {
             </style__TypeText>
             <SelectableText>
                         <style__Amount
+                                    maxDecimalPlaces={18}
                                     value="0.000000000000000001"
                         />
                          
@@ -1438,6 +1449,7 @@ ShallowWrapper {
                                         </style__TypeText>
                                         <SelectableText>
                                                   <style__Amount
+                                                            maxDecimalPlaces={18}
                                                             value="0.000000000000000001"
                                                   />
                                                    
@@ -1526,6 +1538,7 @@ ShallowWrapper {
                                     </style__TypeText>
                                     <SelectableText>
                                                 <style__Amount
+                                                            maxDecimalPlaces={18}
                                                             value="0.000000000000000001"
                                                 />
                                                  
@@ -1649,6 +1662,7 @@ ShallowWrapper {
               </style__TypeText>
               <SelectableText>
                             <style__Amount
+                                          maxDecimalPlaces={18}
                                           value="0.000000000000000001"
                             />
                              
@@ -1891,6 +1905,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     layer="baseLayer"
@@ -1932,6 +1947,7 @@ ShallowWrapper {
                                 </style__TypeText>
                                 <SelectableText>
                                         <style__Amount
+                                                maxDecimalPlaces={18}
                                                 value="0.000000000000000001"
                                         />
                                          
@@ -2020,6 +2036,7 @@ ShallowWrapper {
                               </style__TypeText>
                               <SelectableText>
                                         <style__Amount
+                                                  maxDecimalPlaces={18}
                                                   value="0.000000000000000001"
                                         />
                                          
@@ -2143,6 +2160,7 @@ ShallowWrapper {
             </style__TypeText>
             <SelectableText>
                         <style__Amount
+                                    maxDecimalPlaces={18}
                                     value="0.000000000000000001"
                         />
                          
@@ -2387,6 +2405,7 @@ ShallowWrapper {
                                         </style__TypeText>
                                         <SelectableText>
                                                   <style__Amount
+                                                            maxDecimalPlaces={18}
                                                             value="0.000000000000000001"
                                                   />
                                                    
@@ -2475,6 +2494,7 @@ ShallowWrapper {
                                     </style__TypeText>
                                     <SelectableText>
                                                 <style__Amount
+                                                            maxDecimalPlaces={18}
                                                             value="0.000000000000000001"
                                                 />
                                                  
@@ -2598,6 +2618,7 @@ ShallowWrapper {
               </style__TypeText>
               <SelectableText>
                             <style__Amount
+                                          maxDecimalPlaces={18}
                                           value="0.000000000000000001"
                             />
                              
@@ -2840,6 +2861,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     layer="baseLayer"
@@ -2881,6 +2903,7 @@ ShallowWrapper {
                                 </style__TypeText>
                                 <SelectableText>
                                         <style__Amount
+                                                maxDecimalPlaces={18}
                                                 value="0.000000000000000001"
                                         />
                                          
@@ -2969,6 +2992,7 @@ ShallowWrapper {
                               </style__TypeText>
                               <SelectableText>
                                         <style__Amount
+                                                  maxDecimalPlaces={18}
                                                   value="0.000000000000000001"
                                         />
                                          
@@ -3092,6 +3116,7 @@ ShallowWrapper {
             </style__TypeText>
             <SelectableText>
                         <style__Amount
+                                    maxDecimalPlaces={18}
                                     value="0.000000000000000001"
                         />
                          
@@ -3336,6 +3361,7 @@ ShallowWrapper {
                                         </style__TypeText>
                                         <SelectableText>
                                                   <style__Amount
+                                                            maxDecimalPlaces={18}
                                                             value="0.000000000000000001"
                                                   />
                                                    
@@ -3424,6 +3450,7 @@ ShallowWrapper {
                                     </style__TypeText>
                                     <SelectableText>
                                                 <style__Amount
+                                                            maxDecimalPlaces={18}
                                                             value="0.000000000000000001"
                                                 />
                                                  
@@ -3547,6 +3574,7 @@ ShallowWrapper {
               </style__TypeText>
               <SelectableText>
                             <style__Amount
+                                          maxDecimalPlaces={18}
                                           value="0.000000000000000001"
                             />
                              

--- a/src/components/TransferDescription/index.js
+++ b/src/components/TransferDescription/index.js
@@ -115,7 +115,7 @@ class TransferDescription extends React.PureComponent {
         </Row>
         <Row>
           <TransferDescriptionItem
-            main={<SelectableText><NumericText value={amountToSend.toString()} /> {assetToSend.symbol}</SelectableText>}
+            main={<SelectableText><NumericText maxDecimalPlaces={18} value={amountToSend.toString()} /> {assetToSend.symbol}</SelectableText>}
             subtitle={<NumericText value={usdValueToSend.toString()} type="currency" />}
           />
         </Row>
@@ -130,7 +130,7 @@ class TransferDescription extends React.PureComponent {
         </Row>
         <Row>
           <TransferDescriptionItem
-            main={<SelectableText><NumericText value={transactionFee.amount.toString()} /> {transactionFee.symbol}</SelectableText>}
+            main={<SelectableText><NumericText maxDecimalPlaces={18} value={transactionFee.amount.toString()} /> {transactionFee.symbol}</SelectableText>}
             subtitle={<NumericText value={transactionFee.usdValue.toString()} type="currency" />}
           />
         </Row>
@@ -141,7 +141,7 @@ class TransferDescription extends React.PureComponent {
           </Row>
           <Row>
             <TransferDescriptionItem
-              main={<SelectableText><NumericText value={baseLayerEthBalanceBefore.amount.toString()} /> {'ETH'}</SelectableText>}
+              main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerEthBalanceBefore.amount.toString()} /> {'ETH'}</SelectableText>}
               subtitle={<NumericText value={baseLayerEthBalanceBefore.usdValue.toString()} type="currency" />}
             />
           </Row>
@@ -152,7 +152,7 @@ class TransferDescription extends React.PureComponent {
           </Row>
           <Row>
             <TransferDescriptionItem
-              main={<SelectableText><NumericText value={baseLayerEthBalanceAfter.amount.toString()} /> {'ETH'}</SelectableText>}
+              main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerEthBalanceAfter.amount.toString()} /> {'ETH'}</SelectableText>}
               subtitle={<NumericText value={baseLayerEthBalanceAfter.usdValue.toString()} type="currency" />}
             />
           </Row>
@@ -167,7 +167,7 @@ class TransferDescription extends React.PureComponent {
           </Row>
           <Row>
             <TransferDescriptionItem
-              main={<SelectableText><NumericText value={assetBalanceBefore.amount.toString()} /> {assetToSend.symbol}</SelectableText>}
+              main={<SelectableText><NumericText maxDecimalPlaces={18} value={assetBalanceBefore.amount.toString()} /> {assetToSend.symbol}</SelectableText>}
               subtitle={<NumericText value={assetBalanceBefore.usdValue.toString()} type="currency" />}
             />
           </Row>
@@ -178,7 +178,7 @@ class TransferDescription extends React.PureComponent {
           </Row>
           <Row>
             <TransferDescriptionItem
-              main={<SelectableText><NumericText value={assetBalanceAfter.amount.toString()} /> {assetToSend.symbol}</SelectableText>}
+              main={<SelectableText><NumericText maxDecimalPlaces={18} value={assetBalanceAfter.amount.toString()} /> {assetToSend.symbol}</SelectableText>}
               subtitle={<NumericText value={assetBalanceAfter.usdValue.toString()} type="currency" />}
             />
           </Row>

--- a/src/components/TransferDescription/index.js
+++ b/src/components/TransferDescription/index.js
@@ -116,7 +116,7 @@ class TransferDescription extends React.PureComponent {
         <Row>
           <TransferDescriptionItem
             main={<SelectableText><NumericText maxDecimalPlaces={18} value={amountToSend.toString()} /> {assetToSend.symbol}</SelectableText>}
-            subtitle={<NumericText value={usdValueToSend.toString()} type="currency" />}
+            subtitle={<NumericText value={usdValueToSend.toString()} type="fiat" />}
           />
         </Row>
         <Row>
@@ -131,7 +131,7 @@ class TransferDescription extends React.PureComponent {
         <Row>
           <TransferDescriptionItem
             main={<SelectableText><NumericText maxDecimalPlaces={18} value={transactionFee.amount.toString()} /> {transactionFee.symbol}</SelectableText>}
-            subtitle={<NumericText value={transactionFee.usdValue.toString()} type="currency" />}
+            subtitle={<NumericText value={transactionFee.usdValue.toString()} type="fiat" />}
           />
         </Row>
         {layer === 'baseLayer' &&
@@ -142,7 +142,7 @@ class TransferDescription extends React.PureComponent {
           <Row>
             <TransferDescriptionItem
               main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerEthBalanceBefore.amount.toString()} /> {'ETH'}</SelectableText>}
-              subtitle={<NumericText value={baseLayerEthBalanceBefore.usdValue.toString()} type="currency" />}
+              subtitle={<NumericText value={baseLayerEthBalanceBefore.usdValue.toString()} type="fiat" />}
             />
           </Row>
           <Row>
@@ -153,7 +153,7 @@ class TransferDescription extends React.PureComponent {
           <Row>
             <TransferDescriptionItem
               main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerEthBalanceAfter.amount.toString()} /> {'ETH'}</SelectableText>}
-              subtitle={<NumericText value={baseLayerEthBalanceAfter.usdValue.toString()} type="currency" />}
+              subtitle={<NumericText value={baseLayerEthBalanceAfter.usdValue.toString()} type="fiat" />}
             />
           </Row>
         </div>
@@ -168,7 +168,7 @@ class TransferDescription extends React.PureComponent {
           <Row>
             <TransferDescriptionItem
               main={<SelectableText><NumericText maxDecimalPlaces={18} value={assetBalanceBefore.amount.toString()} /> {assetToSend.symbol}</SelectableText>}
-              subtitle={<NumericText value={assetBalanceBefore.usdValue.toString()} type="currency" />}
+              subtitle={<NumericText value={assetBalanceBefore.usdValue.toString()} type="fiat" />}
             />
           </Row>
           <Row>
@@ -179,7 +179,7 @@ class TransferDescription extends React.PureComponent {
           <Row>
             <TransferDescriptionItem
               main={<SelectableText><NumericText maxDecimalPlaces={18} value={assetBalanceAfter.amount.toString()} /> {assetToSend.symbol}</SelectableText>}
-              subtitle={<NumericText value={assetBalanceAfter.usdValue.toString()} type="currency" />}
+              subtitle={<NumericText value={assetBalanceAfter.usdValue.toString()} type="fiat" />}
             />
           </Row>
         </div>
@@ -189,7 +189,7 @@ class TransferDescription extends React.PureComponent {
         </Row>
         <Row>
           <Balance>
-            {<NumericText large value={walletUsdValueBefore.toString()} type="currency" />}
+            {<NumericText large value={walletUsdValueBefore.toString()} type="fiat" />}
           </Balance>
         </Row>
         <Row>
@@ -197,7 +197,7 @@ class TransferDescription extends React.PureComponent {
         </Row>
         <Row>
           <Balance>
-            {<NumericText large value={walletUsdValueAfter.toString()} type="currency" />}
+            {<NumericText large value={walletUsdValueAfter.toString()} type="fiat" />}
           </Balance>
         </Row>
         <Row>

--- a/src/components/TransferForm/index.js
+++ b/src/components/TransferForm/index.js
@@ -422,7 +422,7 @@ export class TransferForm extends React.PureComponent {
                         />
                       </div>
                       <ETHtoDollar>
-                        {`1 ${assetToSend.symbol} = `}<StyledNumericText value={assetToSendUsdValue.toString()} type="currency" />
+                        {`1 ${assetToSend.symbol} = `}<StyledNumericText value={assetToSendUsdValue.toString()} type="fiat" />
                       </ETHtoDollar>
                     </div>
                   )

--- a/src/components/TransferForm/tests/__snapshots__/index.test.js.snap
+++ b/src/components/TransferForm/tests/__snapshots__/index.test.js.snap
@@ -489,6 +489,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     onSend={[Function]}
@@ -7523,6 +7524,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     onSend={[Function]}
@@ -14280,6 +14282,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     onSend={[Function]}
@@ -21314,6 +21317,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     onSend={[Function]}

--- a/src/components/ui/NumericText/index.js
+++ b/src/components/ui/NumericText/index.js
@@ -8,7 +8,7 @@ export const NumericText = (props) => {
   const { value, type, maxDecimalPlaces, intl } = props;
   const { formatNumber } = intl;
 
-  if (type === 'currency') {
+  if (type === 'fiat') {
     const defaultMaxDecimalPlaces = 2;
     const _maxDecimalPlaces = maxDecimalPlaces || defaultMaxDecimalPlaces;
     return (

--- a/src/components/ui/NumericText/index.js
+++ b/src/components/ui/NumericText/index.js
@@ -1,28 +1,52 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
+import BigNumber from 'bignumber.js';
 import SelectableText from '../SelectableText';
 
-const NumericText = (props) => {
-  const { value, type, intl } = props;
+export const NumericText = (props) => {
+  const { value, type, maxDecimalPlaces, intl } = props;
   const { formatNumber } = intl;
-  const options = {
-    maximumFractionDigits: 6,
-  };
+
   if (type === 'currency') {
-    options.style = 'currency';
-    options.currency = 'USD';
-    options.maximumFractionDigits = 2;
+    const defaultMaxDecimalPlaces = 2;
+    const _maxDecimalPlaces = maxDecimalPlaces || defaultMaxDecimalPlaces;
+    return (
+      <SelectableText {...props}>
+        {formatNumber(value, {
+          style: 'currency',
+          currency: 'USD',
+          maximumFractionDigits: _maxDecimalPlaces,
+        })}
+      </SelectableText>
+    );
+  }
+
+  const defaultMaxDecimalPlaces = 6;
+  const _maxDecimalPlaces = maxDecimalPlaces || defaultMaxDecimalPlaces;
+  const bn = new BigNumber(value);
+
+  if (bn.gte(new BigNumber(10).pow(-_maxDecimalPlaces))) {
+    return (
+      <SelectableText {...props}>
+        {formatNumber(value, {
+          maximumFractionDigits: _maxDecimalPlaces,
+        })}
+      </SelectableText>
+    );
   }
   return (
-    <SelectableText {...props}>{formatNumber(value, options)}</SelectableText>
+    <SelectableText {...props}>
+      {bn.eq(0) ? '0' : bn.toExponential(3)}
+    </SelectableText>
   );
 };
 
 NumericText.propTypes = {
   value: PropTypes.string.isRequired,
-  type: PropTypes.string,
   intl: PropTypes.object,
+  type: PropTypes.string,
+  maxDecimalPlaces: PropTypes.number,
 };
 
 export default injectIntl(NumericText);

--- a/src/components/ui/NumericText/index.js
+++ b/src/components/ui/NumericText/index.js
@@ -26,7 +26,7 @@ export const NumericText = (props) => {
   const _maxDecimalPlaces = maxDecimalPlaces || defaultMaxDecimalPlaces;
   const bn = new BigNumber(value);
 
-  if (bn.gte(new BigNumber(10).pow(-_maxDecimalPlaces))) {
+  if (bn.gte(new BigNumber(10).pow(-_maxDecimalPlaces)) || bn.lte(0)) {
     return (
       <SelectableText {...props}>
         {formatNumber(value, {
@@ -37,7 +37,7 @@ export const NumericText = (props) => {
   }
   return (
     <SelectableText {...props}>
-      {bn.eq(0) ? '0' : bn.toExponential(3)}
+      {bn.toExponential(3)}
     </SelectableText>
   );
 };

--- a/src/components/ui/NumericText/tests/index.test.js
+++ b/src/components/ui/NumericText/tests/index.test.js
@@ -1,0 +1,142 @@
+import React from 'react';
+import {
+  shallow,
+} from 'enzyme';
+import {
+  intl,
+} from 'jest/__mocks__/react-intl';
+
+import { NumericText } from '../index';
+import SelectableText from '../../SelectableText';
+
+describe('<NumericText />', () => {
+  let props;
+  let wrapper;
+  beforeEach(() => {
+    props = {
+      intl,
+    };
+  });
+  describe('not currency type', () => {
+    describe('without maxDecimalPlaces param', () => {
+      describe('when value is greater or equal to default 6 decimal places', () => {
+        [
+          '0.000001',
+          '0.00001',
+          '0.0001',
+          '0.001',
+          '0.01',
+          '0.1',
+          '1',
+          '1.1',
+        ].forEach((val) => {
+          it(`should render the same value ${val}`, () => {
+            wrapper = shallow(<NumericText
+              {...props}
+              value={val}
+            />
+            );
+            expect(getInnerText(wrapper.find(SelectableText).html())).toContain(val);
+          });
+        });
+      });
+      describe('when value is less than default 6 decimal places', () => {
+        [
+          ['0.0000001', '1.000e-7'],
+          ['0.00000001', '1.000e-8'],
+          ['0.000000123456', '1.235e-7'],
+        ].forEach(([val, expected]) => {
+          it(`should render the exponential value ${val}`, () => {
+            wrapper = shallow(<NumericText
+              {...props}
+              value={val}
+            />
+            );
+            expect(getInnerText(wrapper.find(SelectableText).html())).toContain(expected);
+          });
+        });
+      });
+    });
+    describe('with maxDecimalPlaces param', () => {
+      describe('when maxDecimalPlaces param is 3', () => {
+        [
+          ['10000', '10000'],
+          ['0.001', '0.001'],
+          ['0.0001', '1.000e-4'],
+          ['0.000000123456', '1.235e-7'],
+        ].forEach(([val, expected]) => {
+          it(`should render ${expected} for value ${val}`, () => {
+            wrapper = shallow(<NumericText
+              {...props}
+              value={val}
+              maxDecimalPlaces={3}
+            />
+            );
+            expect(getInnerText(wrapper.find(SelectableText).html())).toContain(expected);
+          });
+        });
+      });
+      describe('when maxDecimalPlaces param is 20', () => {
+        [
+          ['10000', '10000'],
+          ['0.001', '0.001'],
+          ['0.0001', '0.0001'],
+          ['0.000000123456', '0.000000123456'],
+          ['0.00000012345678910111', '0.00000012345678910111'],
+          ['0.0000000000000000000123456', '0.0000000000000000000123456'],
+          ['0.00000000000000000000123456', '1.235e-21'],
+        ].forEach(([val, expected]) => {
+          it(`should render ${expected} for value ${val}`, () => {
+            wrapper = shallow(<NumericText
+              {...props}
+              value={val}
+              maxDecimalPlaces={20}
+            />
+            );
+            expect(getInnerText(wrapper.find(SelectableText).html())).toContain(expected);
+          });
+        });
+      });
+    });
+    describe('when value is 0', () => {
+      it('should render 0', () => {
+        wrapper = shallow(<NumericText
+          {...props}
+          value={'0'}
+        />
+        );
+        expect(getInnerText(wrapper.find(SelectableText).html())).toEqual('0');
+      });
+    });
+  });
+  describe('currency type', () => {
+    describe('with maxDecimalPlaces param', () => {
+      it('should pass correct params to the #formatNumber()', () => {
+        wrapper = shallow(<NumericText
+          {...props}
+          type={'currency'}
+          value={'0.001'}
+          maxDecimalPlaces={3}
+        />
+        );
+        expect(getInnerText(wrapper.find(SelectableText).html())).toEqual('0.001 {&quot;style&quot;:&quot;currency&quot;,&quot;currency&quot;:&quot;USD&quot;,&quot;maximumFractionDigits&quot;:3}');
+      });
+    });
+    describe('without maxDecimalPlaces param', () => {
+      it('should pass correct params to the #formatNumber()', () => {
+        wrapper = shallow(<NumericText
+          {...props}
+          type={'currency'}
+          value={'0.001'}
+        />
+        );
+        expect(getInnerText(wrapper.find(SelectableText).html())).toEqual('0.001 {&quot;style&quot;:&quot;currency&quot;,&quot;currency&quot;:&quot;USD&quot;,&quot;maximumFractionDigits&quot;:2}');
+      });
+    });
+  });
+});
+
+function getInnerText(str) {
+  const reg = /<span[^>]*>([^<]+)<\/span>/g;
+  return reg.exec(str)[1];
+}

--- a/src/components/ui/NumericText/tests/index.test.js
+++ b/src/components/ui/NumericText/tests/index.test.js
@@ -108,7 +108,7 @@ describe('<NumericText />', () => {
       it('should pass correct params to the #formatNumber()', () => {
         wrapper = shallow(<NumericText
           {...props}
-          type={'currency'}
+          type={'fiat'}
           value={'0.001'}
           maxDecimalPlaces={3}
         />
@@ -120,7 +120,7 @@ describe('<NumericText />', () => {
       it('should pass correct params to the #formatNumber()', () => {
         wrapper = shallow(<NumericText
           {...props}
-          type={'currency'}
+          type={'fiat'}
           value={'0.001'}
         />
         );

--- a/src/components/ui/NumericText/tests/index.test.js
+++ b/src/components/ui/NumericText/tests/index.test.js
@@ -21,12 +21,15 @@ describe('<NumericText />', () => {
     describe('without maxDecimalPlaces param', () => {
       describe('when value is greater or equal to default 6 decimal places', () => {
         [
+          '-0.0000001',
+          '-0.000001',
           '0.000001',
           '0.00001',
           '0.0001',
           '0.001',
           '0.01',
           '0.1',
+          '0',
           '1',
           '1.1',
         ].forEach((val) => {
@@ -36,7 +39,8 @@ describe('<NumericText />', () => {
               value={val}
             />
             );
-            expect(getInnerText(wrapper.find(SelectableText).html())).toContain(val);
+            const paramString = '{&quot;maximumFractionDigits&quot;:6}';
+            expect(getInnerText(wrapper.find(SelectableText).html())).toEqual(`${val} ${paramString}`);
           });
         });
       });
@@ -96,16 +100,6 @@ describe('<NumericText />', () => {
             expect(getInnerText(wrapper.find(SelectableText).html())).toContain(expected);
           });
         });
-      });
-    });
-    describe('when value is 0', () => {
-      it('should render 0', () => {
-        wrapper = shallow(<NumericText
-          {...props}
-          value={'0'}
-        />
-        );
-        expect(getInnerText(wrapper.find(SelectableText).html())).toEqual('0');
       });
     });
   });

--- a/src/containers/ConnectionStatus/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/ConnectionStatus/tests/__snapshots__/index.test.js.snap
@@ -27,6 +27,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
 />,
@@ -599,6 +600,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
 />,
@@ -1171,6 +1173,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
 />,

--- a/src/containers/ContactBook/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/ContactBook/tests/__snapshots__/index.test.js.snap
@@ -25,6 +25,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     recentContacts={

--- a/src/containers/Nahmii/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/Nahmii/tests/__snapshots__/index.test.js.snap
@@ -16,6 +16,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     match={

--- a/src/containers/NahmiiAirdriipRegistration/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/NahmiiAirdriipRegistration/tests/__snapshots__/index.test.js.snap
@@ -14,6 +14,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     setCurrentWallet={[Function]}
@@ -408,6 +409,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     setCurrentWallet={[Function]}
@@ -761,6 +763,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     setCurrentWallet={[Function]}
@@ -944,6 +947,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     notify={[Function]}
@@ -1646,6 +1650,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerInfo={
@@ -1746,6 +1751,7 @@ ShallowWrapper {
                 intl={
                         Object {
                                 "formatMessage": [Function],
+                                "formatNumber": [Function],
                               }
                 }
                 notify={[Function]}
@@ -1794,6 +1800,7 @@ ShallowWrapper {
             intl={
                         Object {
                                     "formatMessage": [Function],
+                                    "formatNumber": [Function],
                                   }
             }
             notify={[Function]}
@@ -1850,6 +1857,7 @@ ShallowWrapper {
             "changeManualSignedMessage": [Function],
             "intl": Object {
               "formatMessage": [Function],
+              "formatNumber": [Function],
             },
             "notify": [Function],
             "signedMessageValue": "0x8bfb0e2034f6e5e311c100308264551719db9d674dfbd5b20c54e545d310b6c41bfb02f74c5f2b49d6a55e133ee2d290578f90e9f810d6887a5b229282f6b8a600",
@@ -1944,6 +1952,7 @@ ShallowWrapper {
                     intl={
                               Object {
                                         "formatMessage": [Function],
+                                        "formatNumber": [Function],
                                       }
                     }
                     notify={[Function]}
@@ -1992,6 +2001,7 @@ ShallowWrapper {
               intl={
                             Object {
                                           "formatMessage": [Function],
+                                          "formatNumber": [Function],
                                         }
               }
               notify={[Function]}
@@ -2048,6 +2058,7 @@ ShallowWrapper {
               "changeManualSignedMessage": [Function],
               "intl": Object {
                 "formatMessage": [Function],
+                "formatNumber": [Function],
               },
               "notify": [Function],
               "signedMessageValue": "0x8bfb0e2034f6e5e311c100308264551719db9d674dfbd5b20c54e545d310b6c41bfb02f74c5f2b49d6a55e133ee2d290578f90e9f810d6887a5b229282f6b8a600",
@@ -2619,6 +2630,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerInfo={
@@ -3083,6 +3095,7 @@ ShallowWrapper {
                 intl={
                         Object {
                                 "formatMessage": [Function],
+                                "formatNumber": [Function],
                               }
                 }
                 setCurrentWallet={[Function]}
@@ -3540,6 +3553,7 @@ ShallowWrapper {
             intl={
                         Object {
                                     "formatMessage": [Function],
+                                    "formatNumber": [Function],
                                   }
             }
             setCurrentWallet={[Function]}
@@ -4003,6 +4017,7 @@ ShallowWrapper {
 },
             "intl": Object {
               "formatMessage": [Function],
+              "formatNumber": [Function],
             },
             "setCurrentWallet": [Function],
             "showHwPrompt": false,
@@ -4511,6 +4526,7 @@ ShallowWrapper {
                     intl={
                               Object {
                                         "formatMessage": [Function],
+                                        "formatNumber": [Function],
                                       }
                     }
                     setCurrentWallet={[Function]}
@@ -4968,6 +4984,7 @@ ShallowWrapper {
               intl={
                             Object {
                                           "formatMessage": [Function],
+                                          "formatNumber": [Function],
                                         }
               }
               setCurrentWallet={[Function]}
@@ -5431,6 +5448,7 @@ ShallowWrapper {
 },
               "intl": Object {
                 "formatMessage": [Function],
+                "formatNumber": [Function],
               },
               "setCurrentWallet": [Function],
               "showHwPrompt": false,
@@ -6052,6 +6070,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerInfo={
@@ -6150,6 +6169,7 @@ ShallowWrapper {
                 intl={
                         Object {
                                 "formatMessage": [Function],
+                                "formatNumber": [Function],
                               }
                 }
         />
@@ -6173,6 +6193,7 @@ ShallowWrapper {
             intl={
                         Object {
                                     "formatMessage": [Function],
+                                    "formatNumber": [Function],
                                   }
             }
 />,
@@ -6207,6 +6228,7 @@ ShallowWrapper {
             "changeStage": [Function],
             "intl": Object {
               "formatMessage": [Function],
+              "formatNumber": [Function],
             },
           },
           "ref": null,
@@ -6241,6 +6263,7 @@ ShallowWrapper {
                     intl={
                               Object {
                                         "formatMessage": [Function],
+                                        "formatNumber": [Function],
                                       }
                     }
           />
@@ -6264,6 +6287,7 @@ ShallowWrapper {
               intl={
                             Object {
                                           "formatMessage": [Function],
+                                          "formatNumber": [Function],
                                         }
               }
 />,
@@ -6298,6 +6322,7 @@ ShallowWrapper {
               "changeStage": [Function],
               "intl": Object {
                 "formatMessage": [Function],
+                "formatNumber": [Function],
               },
             },
             "ref": null,
@@ -6811,6 +6836,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerInfo={
@@ -6909,6 +6935,7 @@ ShallowWrapper {
                 intl={
                         Object {
                                 "formatMessage": [Function],
+                                "formatNumber": [Function],
                               }
                 }
         />
@@ -6938,6 +6965,7 @@ ShallowWrapper {
             intl={
                         Object {
                                     "formatMessage": [Function],
+                                    "formatNumber": [Function],
                                   }
             }
 />,
@@ -6977,6 +7005,7 @@ ShallowWrapper {
             "changeStage": [Function],
             "intl": Object {
               "formatMessage": [Function],
+              "formatNumber": [Function],
             },
           },
           "ref": null,
@@ -7024,6 +7053,7 @@ ShallowWrapper {
                     intl={
                               Object {
                                         "formatMessage": [Function],
+                                        "formatNumber": [Function],
                                       }
                     }
           />
@@ -7053,6 +7083,7 @@ ShallowWrapper {
               intl={
                             Object {
                                           "formatMessage": [Function],
+                                          "formatNumber": [Function],
                                         }
               }
 />,
@@ -7092,6 +7123,7 @@ ShallowWrapper {
               "changeStage": [Function],
               "intl": Object {
                 "formatMessage": [Function],
+                "formatNumber": [Function],
               },
             },
             "ref": null,
@@ -7615,6 +7647,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerInfo={
@@ -7707,6 +7740,7 @@ ShallowWrapper {
                 intl={
                         Object {
                                 "formatMessage": [Function],
+                                "formatNumber": [Function],
                               }
                 }
         />
@@ -7725,6 +7759,7 @@ ShallowWrapper {
             intl={
                         Object {
                                     "formatMessage": [Function],
+                                    "formatNumber": [Function],
                                   }
             }
 />,
@@ -7746,6 +7781,7 @@ ShallowWrapper {
             "changeStage": [Function],
             "intl": Object {
               "formatMessage": [Function],
+              "formatNumber": [Function],
             },
           },
           "ref": null,
@@ -7774,6 +7810,7 @@ ShallowWrapper {
                     intl={
                               Object {
                                         "formatMessage": [Function],
+                                        "formatNumber": [Function],
                                       }
                     }
           />
@@ -7792,6 +7829,7 @@ ShallowWrapper {
               intl={
                             Object {
                                           "formatMessage": [Function],
+                                          "formatNumber": [Function],
                                         }
               }
 />,
@@ -7813,6 +7851,7 @@ ShallowWrapper {
               "changeStage": [Function],
               "intl": Object {
                 "formatMessage": [Function],
+                "formatNumber": [Function],
               },
             },
             "ref": null,
@@ -7849,6 +7888,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
 />,

--- a/src/containers/NahmiiDeposit/index.js
+++ b/src/containers/NahmiiDeposit/index.js
@@ -377,7 +377,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
             </Row>
             <Row>
               <TransferDescriptionItem
-                main={<SelectableText><NumericText value={amountToDeposit.toString()} /> {assetToDeposit.symbol}</SelectableText>}
+                main={<SelectableText><NumericText maxDecimalPlaces={18} value={amountToDeposit.toString()} /> {assetToDeposit.symbol}</SelectableText>}
                 subtitle={<NumericText value={usdValueToDeposit.toString()} type="currency" />}
               />
             </Row>
@@ -390,7 +390,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
             </Row>
             <Row>
               <TransferDescriptionItem
-                main={<SelectableText><NumericText value={transactionFee.amount.toString()} /> {'ETH'}</SelectableText>}
+                main={<SelectableText><NumericText maxDecimalPlaces={18} value={transactionFee.amount.toString()} /> {'ETH'}</SelectableText>}
                 subtitle={<NumericText value={transactionFee.usdValue.toString()} type="currency" />}
               />
             </Row>
@@ -399,7 +399,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
             </Row>
             <Row>
               <TransferDescriptionItem
-                main={<SelectableText><NumericText value={baseLayerEthBalanceBefore.amount.toString()} /> {'ETH'}</SelectableText>}
+                main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerEthBalanceBefore.amount.toString()} /> {'ETH'}</SelectableText>}
                 subtitle={<NumericText value={baseLayerEthBalanceBefore.usdValue.toString()} type="currency" />}
               />
             </Row>
@@ -410,7 +410,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
             </Row>
             <Row>
               <TransferDescriptionItem
-                main={<SelectableText><NumericText value={baseLayerEthBalanceAfter.amount.toString()} /> {'ETH'}</SelectableText>}
+                main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerEthBalanceAfter.amount.toString()} /> {'ETH'}</SelectableText>}
                 subtitle={<NumericText value={baseLayerEthBalanceAfter.usdValue.toString()} type="currency" />}
               />
             </Row>
@@ -421,7 +421,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
               </Row>
               <Row>
                 <TransferDescriptionItem
-                  main={<SelectableText><NumericText value={nahmiiBalanceBefore.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
+                  main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiBalanceBefore.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
                   subtitle={<NumericText value={nahmiiBalanceBefore.usdValue.toString()} type="currency" />}
                 />
               </Row>
@@ -432,7 +432,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
               </Row>
               <Row>
                 <TransferDescriptionItem
-                  main={<SelectableText><NumericText value={nahmiiBalanceAfter.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
+                  main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiBalanceAfter.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
                   subtitle={<NumericText value={nahmiiBalanceAfter.usdValue.toString()} type="currency" />}
                 />
               </Row>
@@ -445,7 +445,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
               </Row>
               <Row>
                 <TransferDescriptionItem
-                  main={<SelectableText><NumericText value={baseLayerBalanceBefore.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
+                  main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerBalanceBefore.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
                   subtitle={<NumericText value={baseLayerBalanceBefore.usdValue.toString()} type="currency" />}
                 />
               </Row>
@@ -456,7 +456,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
               </Row>
               <Row>
                 <TransferDescriptionItem
-                  main={<SelectableText><NumericText value={baseLayerBalanceAfter.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
+                  main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerBalanceAfter.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
                   subtitle={<NumericText value={baseLayerBalanceAfter.usdValue.toString()} type="currency" />}
                 />
               </Row>
@@ -465,7 +465,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
               </Row>
               <Row>
                 <TransferDescriptionItem
-                  main={<SelectableText><NumericText value={nahmiiBalanceBefore.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
+                  main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiBalanceBefore.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
                   subtitle={<NumericText value={nahmiiBalanceBefore.usdValue.toString()} type="currency" />}
                 />
               </Row>
@@ -476,7 +476,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
               </Row>
               <Row>
                 <TransferDescriptionItem
-                  main={<SelectableText><NumericText value={nahmiiBalanceAfter.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
+                  main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiBalanceAfter.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
                   subtitle={<NumericText value={nahmiiBalanceAfter.usdValue.toString()} type="currency" />}
                 />
               </Row>

--- a/src/containers/NahmiiDeposit/index.js
+++ b/src/containers/NahmiiDeposit/index.js
@@ -367,7 +367,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
                 onChange={this.onGasChange}
               />
               <DollarPrice>
-                {`1 ${assetToDeposit.symbol} = `}<StyledNumericText value={assetToDepositUsdValue.toString()} type="currency" />
+                {`1 ${assetToDeposit.symbol} = `}<StyledNumericText value={assetToDepositUsdValue.toString()} type="fiat" />
               </DollarPrice>
             </Form>
           </div>
@@ -378,7 +378,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
             <Row>
               <TransferDescriptionItem
                 main={<SelectableText><NumericText maxDecimalPlaces={18} value={amountToDeposit.toString()} /> {assetToDeposit.symbol}</SelectableText>}
-                subtitle={<NumericText value={usdValueToDeposit.toString()} type="currency" />}
+                subtitle={<NumericText value={usdValueToDeposit.toString()} type="fiat" />}
               />
             </Row>
             <Row>
@@ -391,7 +391,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
             <Row>
               <TransferDescriptionItem
                 main={<SelectableText><NumericText maxDecimalPlaces={18} value={transactionFee.amount.toString()} /> {'ETH'}</SelectableText>}
-                subtitle={<NumericText value={transactionFee.usdValue.toString()} type="currency" />}
+                subtitle={<NumericText value={transactionFee.usdValue.toString()} type="fiat" />}
               />
             </Row>
             <Row>
@@ -400,7 +400,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
             <Row>
               <TransferDescriptionItem
                 main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerEthBalanceBefore.amount.toString()} /> {'ETH'}</SelectableText>}
-                subtitle={<NumericText value={baseLayerEthBalanceBefore.usdValue.toString()} type="currency" />}
+                subtitle={<NumericText value={baseLayerEthBalanceBefore.usdValue.toString()} type="fiat" />}
               />
             </Row>
             <Row>
@@ -411,7 +411,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
             <Row>
               <TransferDescriptionItem
                 main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerEthBalanceAfter.amount.toString()} /> {'ETH'}</SelectableText>}
-                subtitle={<NumericText value={baseLayerEthBalanceAfter.usdValue.toString()} type="currency" />}
+                subtitle={<NumericText value={baseLayerEthBalanceAfter.usdValue.toString()} type="fiat" />}
               />
             </Row>
             {assetToDeposit.symbol === 'ETH' &&
@@ -422,7 +422,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
               <Row>
                 <TransferDescriptionItem
                   main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiBalanceBefore.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
-                  subtitle={<NumericText value={nahmiiBalanceBefore.usdValue.toString()} type="currency" />}
+                  subtitle={<NumericText value={nahmiiBalanceBefore.usdValue.toString()} type="fiat" />}
                 />
               </Row>
               <Row>
@@ -433,7 +433,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
               <Row>
                 <TransferDescriptionItem
                   main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiBalanceAfter.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
-                  subtitle={<NumericText value={nahmiiBalanceAfter.usdValue.toString()} type="currency" />}
+                  subtitle={<NumericText value={nahmiiBalanceAfter.usdValue.toString()} type="fiat" />}
                 />
               </Row>
             </div>
@@ -446,7 +446,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
               <Row>
                 <TransferDescriptionItem
                   main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerBalanceBefore.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
-                  subtitle={<NumericText value={baseLayerBalanceBefore.usdValue.toString()} type="currency" />}
+                  subtitle={<NumericText value={baseLayerBalanceBefore.usdValue.toString()} type="fiat" />}
                 />
               </Row>
               <Row>
@@ -457,7 +457,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
               <Row>
                 <TransferDescriptionItem
                   main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerBalanceAfter.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
-                  subtitle={<NumericText value={baseLayerBalanceAfter.usdValue.toString()} type="currency" />}
+                  subtitle={<NumericText value={baseLayerBalanceAfter.usdValue.toString()} type="fiat" />}
                 />
               </Row>
               <Row>
@@ -466,7 +466,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
               <Row>
                 <TransferDescriptionItem
                   main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiBalanceBefore.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
-                  subtitle={<NumericText value={nahmiiBalanceBefore.usdValue.toString()} type="currency" />}
+                  subtitle={<NumericText value={nahmiiBalanceBefore.usdValue.toString()} type="fiat" />}
                 />
               </Row>
               <Row>
@@ -477,7 +477,7 @@ export class NahmiiDeposit extends React.Component { // eslint-disable-line reac
               <Row>
                 <TransferDescriptionItem
                   main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiBalanceAfter.amount.toString()} /> {assetToDeposit.symbol}</SelectableText>}
-                  subtitle={<NumericText value={nahmiiBalanceAfter.usdValue.toString()} type="currency" />}
+                  subtitle={<NumericText value={nahmiiBalanceAfter.usdValue.toString()} type="fiat" />}
                 />
               </Row>
             </div>

--- a/src/containers/NahmiiDeposit/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/NahmiiDeposit/tests/__snapshots__/index.test.js.snap
@@ -717,7 +717,7 @@ ShallowWrapper {
                         <style__DollarPrice>
                                 1 ETH = 
                                 <style__StyledNumericText
-                                        type="currency"
+                                        type="fiat"
                                         value="412"
                                 />
                         </style__DollarPrice>
@@ -755,7 +755,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="0"
                                         />
                                 }
@@ -790,7 +790,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="2.472"
                                         />
                                 }
@@ -823,7 +823,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="81.962044"
                                         />
                                 }
@@ -856,7 +856,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="79.490044"
                                         />
                                 }
@@ -890,7 +890,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                 <NumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="41.2"
                                                 />
                                         }
@@ -923,7 +923,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                 <NumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="41.2"
                                                 />
                                         }
@@ -1082,7 +1082,7 @@ ShallowWrapper {
                         <style__DollarPrice>
                                     1 ETH = 
                                     <style__StyledNumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="412"
                                     />
                         </style__DollarPrice>
@@ -1120,7 +1120,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                                 />
                                     }
@@ -1155,7 +1155,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                                 />
                                     }
@@ -1188,7 +1188,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                                 />
                                     }
@@ -1221,7 +1221,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                                 />
                                     }
@@ -1255,7 +1255,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                             <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                             />
                                                 }
@@ -1288,7 +1288,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                             <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                             />
                                                 }
@@ -1444,7 +1444,7 @@ ShallowWrapper {
               <style__DollarPrice>
                             1 ETH = 
                             <style__StyledNumericText
-                                          type="currency"
+                                          type="fiat"
                                           value="412"
                             />
               </style__DollarPrice>
@@ -1534,7 +1534,7 @@ ShallowWrapper {
                 <style__DollarPrice>
                   1 ETH = 
                   <style__StyledNumericText
-                                    type="currency"
+                                    type="fiat"
                                     value="412"
                   />
 </style__DollarPrice>,
@@ -1715,7 +1715,7 @@ ShallowWrapper {
                   "children": Array [
                     "1 ETH = ",
                     <style__StyledNumericText
-                      type="currency"
+                      type="fiat"
                       value="412"
 />,
                   ],
@@ -1728,7 +1728,7 @@ ShallowWrapper {
                     "key": undefined,
                     "nodeType": "class",
                     "props": Object {
-                      "type": "currency",
+                      "type": "fiat",
                       "value": "412",
                     },
                     "ref": null,
@@ -1774,7 +1774,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="0"
                                                 />
                                 }
@@ -1809,7 +1809,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="2.472"
                                                 />
                                 }
@@ -1842,7 +1842,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="81.962044"
                                                 />
                                 }
@@ -1875,7 +1875,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="79.490044"
                                                 />
                                 }
@@ -1909,7 +1909,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                 <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                                 />
                                                 }
@@ -1942,7 +1942,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                 <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                                 />
                                                 }
@@ -2062,7 +2062,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="0"
                                     />
                   }
@@ -2084,7 +2084,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="0"
 />,
                 },
@@ -2158,7 +2158,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="2.472"
                                     />
                   }
@@ -2180,7 +2180,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="2.472"
 />,
                 },
@@ -2245,7 +2245,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="81.962044"
                                     />
                   }
@@ -2267,7 +2267,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="81.962044"
 />,
                 },
@@ -2332,7 +2332,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="79.490044"
                                     />
                   }
@@ -2354,7 +2354,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="79.490044"
 />,
                 },
@@ -2397,7 +2397,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                             <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                             />
                                         }
@@ -2430,7 +2430,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                             <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                             />
                                         }
@@ -2495,7 +2495,7 @@ ShallowWrapper {
                       }
                       subtitle={
                                             <NumericText
-                                                                  type="currency"
+                                                                  type="fiat"
                                                                   value="41.2"
                                             />
                       }
@@ -2517,7 +2517,7 @@ ShallowWrapper {
                         ETH
 </SelectableText>,
                       "subtitle": <NumericText
-                        type="currency"
+                        type="fiat"
                         value="41.2"
 />,
                     },
@@ -2582,7 +2582,7 @@ ShallowWrapper {
                       }
                       subtitle={
                                             <NumericText
-                                                                  type="currency"
+                                                                  type="fiat"
                                                                   value="41.2"
                                             />
                       }
@@ -2604,7 +2604,7 @@ ShallowWrapper {
                         ETH
 </SelectableText>,
                       "subtitle": <NumericText
-                        type="currency"
+                        type="fiat"
                         value="41.2"
 />,
                     },
@@ -2976,7 +2976,7 @@ ShallowWrapper {
                               <style__DollarPrice>
                                         1 ETH = 
                                         <style__StyledNumericText
-                                                  type="currency"
+                                                  type="fiat"
                                                   value="412"
                                         />
                               </style__DollarPrice>
@@ -3014,7 +3014,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                                   />
                                         }
@@ -3049,7 +3049,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                                   />
                                         }
@@ -3082,7 +3082,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                                   />
                                         }
@@ -3115,7 +3115,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                                   />
                                         }
@@ -3149,7 +3149,7 @@ ShallowWrapper {
                                                   }
                                                   subtitle={
                                                             <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="41.2"
                                                             />
                                                   }
@@ -3182,7 +3182,7 @@ ShallowWrapper {
                                                   }
                                                   subtitle={
                                                             <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="41.2"
                                                             />
                                                   }
@@ -3341,7 +3341,7 @@ ShallowWrapper {
                             <style__DollarPrice>
                                           1 ETH = 
                                           <style__StyledNumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="412"
                                           />
                             </style__DollarPrice>
@@ -3379,7 +3379,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="0"
                                                         />
                                           }
@@ -3414,7 +3414,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="2.472"
                                                         />
                                           }
@@ -3447,7 +3447,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="81.962044"
                                                         />
                                           }
@@ -3480,7 +3480,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="79.490044"
                                                         />
                                           }
@@ -3514,7 +3514,7 @@ ShallowWrapper {
                                                         }
                                                         subtitle={
                                                                       <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="41.2"
                                                                       />
                                                         }
@@ -3547,7 +3547,7 @@ ShallowWrapper {
                                                         }
                                                         subtitle={
                                                                       <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="41.2"
                                                                       />
                                                         }
@@ -3703,7 +3703,7 @@ ShallowWrapper {
                 <style__DollarPrice>
                                 1 ETH = 
                                 <style__StyledNumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="412"
                                 />
                 </style__DollarPrice>
@@ -3793,7 +3793,7 @@ ShallowWrapper {
                   <style__DollarPrice>
                     1 ETH = 
                     <style__StyledNumericText
-                                        type="currency"
+                                        type="fiat"
                                         value="412"
                     />
 </style__DollarPrice>,
@@ -3974,7 +3974,7 @@ ShallowWrapper {
                     "children": Array [
                       "1 ETH = ",
                       <style__StyledNumericText
-                        type="currency"
+                        type="fiat"
                         value="412"
 />,
                     ],
@@ -3987,7 +3987,7 @@ ShallowWrapper {
                       "key": undefined,
                       "nodeType": "class",
                       "props": Object {
-                        "type": "currency",
+                        "type": "fiat",
                         "value": "412",
                       },
                       "ref": null,
@@ -4033,7 +4033,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="0"
                                                       />
                                     }
@@ -4068,7 +4068,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="2.472"
                                                       />
                                     }
@@ -4101,7 +4101,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="81.962044"
                                                       />
                                     }
@@ -4134,7 +4134,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="79.490044"
                                                       />
                                     }
@@ -4168,7 +4168,7 @@ ShallowWrapper {
                                                       }
                                                       subtitle={
                                                                         <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="41.2"
                                                                         />
                                                       }
@@ -4201,7 +4201,7 @@ ShallowWrapper {
                                                       }
                                                       subtitle={
                                                                         <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="41.2"
                                                                         />
                                                       }
@@ -4321,7 +4321,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                         />
                     }
@@ -4343,7 +4343,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="0"
 />,
                   },
@@ -4417,7 +4417,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                         />
                     }
@@ -4439,7 +4439,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="2.472"
 />,
                   },
@@ -4504,7 +4504,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                         />
                     }
@@ -4526,7 +4526,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="81.962044"
 />,
                   },
@@ -4591,7 +4591,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                         />
                     }
@@ -4613,7 +4613,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="79.490044"
 />,
                   },
@@ -4656,7 +4656,7 @@ ShallowWrapper {
                                             }
                                             subtitle={
                                                                   <NumericText
-                                                                                        type="currency"
+                                                                                        type="fiat"
                                                                                         value="41.2"
                                                                   />
                                             }
@@ -4689,7 +4689,7 @@ ShallowWrapper {
                                             }
                                             subtitle={
                                                                   <NumericText
-                                                                                        type="currency"
+                                                                                        type="fiat"
                                                                                         value="41.2"
                                                                   />
                                             }
@@ -4754,7 +4754,7 @@ ShallowWrapper {
                         }
                         subtitle={
                                                 <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                 />
                         }
@@ -4776,7 +4776,7 @@ ShallowWrapper {
                           ETH
 </SelectableText>,
                         "subtitle": <NumericText
-                          type="currency"
+                          type="fiat"
                           value="41.2"
 />,
                       },
@@ -4841,7 +4841,7 @@ ShallowWrapper {
                         }
                         subtitle={
                                                 <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                 />
                         }
@@ -4863,7 +4863,7 @@ ShallowWrapper {
                           ETH
 </SelectableText>,
                         "subtitle": <NumericText
-                          type="currency"
+                          type="fiat"
                           value="41.2"
 />,
                       },
@@ -5865,7 +5865,7 @@ ShallowWrapper {
                         <style__DollarPrice>
                                 1 ETH = 
                                 <style__StyledNumericText
-                                        type="currency"
+                                        type="fiat"
                                         value="412"
                                 />
                         </style__DollarPrice>
@@ -5903,7 +5903,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="0"
                                         />
                                 }
@@ -5938,7 +5938,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="2.472"
                                         />
                                 }
@@ -5971,7 +5971,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="81.962044"
                                         />
                                 }
@@ -6004,7 +6004,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="79.490044"
                                         />
                                 }
@@ -6038,7 +6038,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                 <NumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="41.2"
                                                 />
                                         }
@@ -6071,7 +6071,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                 <NumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="41.2"
                                                 />
                                         }
@@ -6230,7 +6230,7 @@ ShallowWrapper {
                         <style__DollarPrice>
                                     1 ETH = 
                                     <style__StyledNumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="412"
                                     />
                         </style__DollarPrice>
@@ -6268,7 +6268,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                                 />
                                     }
@@ -6303,7 +6303,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                                 />
                                     }
@@ -6336,7 +6336,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                                 />
                                     }
@@ -6369,7 +6369,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                                 />
                                     }
@@ -6403,7 +6403,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                             <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                             />
                                                 }
@@ -6436,7 +6436,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                             <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                             />
                                                 }
@@ -6592,7 +6592,7 @@ ShallowWrapper {
               <style__DollarPrice>
                             1 ETH = 
                             <style__StyledNumericText
-                                          type="currency"
+                                          type="fiat"
                                           value="412"
                             />
               </style__DollarPrice>
@@ -6682,7 +6682,7 @@ ShallowWrapper {
                 <style__DollarPrice>
                   1 ETH = 
                   <style__StyledNumericText
-                                    type="currency"
+                                    type="fiat"
                                     value="412"
                   />
 </style__DollarPrice>,
@@ -6863,7 +6863,7 @@ ShallowWrapper {
                   "children": Array [
                     "1 ETH = ",
                     <style__StyledNumericText
-                      type="currency"
+                      type="fiat"
                       value="412"
 />,
                   ],
@@ -6876,7 +6876,7 @@ ShallowWrapper {
                     "key": undefined,
                     "nodeType": "class",
                     "props": Object {
-                      "type": "currency",
+                      "type": "fiat",
                       "value": "412",
                     },
                     "ref": null,
@@ -6922,7 +6922,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="0"
                                                 />
                                 }
@@ -6957,7 +6957,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="2.472"
                                                 />
                                 }
@@ -6990,7 +6990,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="81.962044"
                                                 />
                                 }
@@ -7023,7 +7023,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="79.490044"
                                                 />
                                 }
@@ -7057,7 +7057,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                 <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                                 />
                                                 }
@@ -7090,7 +7090,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                 <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                                 />
                                                 }
@@ -7210,7 +7210,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="0"
                                     />
                   }
@@ -7232,7 +7232,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="0"
 />,
                 },
@@ -7306,7 +7306,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="2.472"
                                     />
                   }
@@ -7328,7 +7328,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="2.472"
 />,
                 },
@@ -7393,7 +7393,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="81.962044"
                                     />
                   }
@@ -7415,7 +7415,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="81.962044"
 />,
                 },
@@ -7480,7 +7480,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="79.490044"
                                     />
                   }
@@ -7502,7 +7502,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="79.490044"
 />,
                 },
@@ -7545,7 +7545,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                             <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                             />
                                         }
@@ -7578,7 +7578,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                             <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                             />
                                         }
@@ -7643,7 +7643,7 @@ ShallowWrapper {
                       }
                       subtitle={
                                             <NumericText
-                                                                  type="currency"
+                                                                  type="fiat"
                                                                   value="41.2"
                                             />
                       }
@@ -7665,7 +7665,7 @@ ShallowWrapper {
                         ETH
 </SelectableText>,
                       "subtitle": <NumericText
-                        type="currency"
+                        type="fiat"
                         value="41.2"
 />,
                     },
@@ -7730,7 +7730,7 @@ ShallowWrapper {
                       }
                       subtitle={
                                             <NumericText
-                                                                  type="currency"
+                                                                  type="fiat"
                                                                   value="41.2"
                                             />
                       }
@@ -7752,7 +7752,7 @@ ShallowWrapper {
                         ETH
 </SelectableText>,
                       "subtitle": <NumericText
-                        type="currency"
+                        type="fiat"
                         value="41.2"
 />,
                     },
@@ -8124,7 +8124,7 @@ ShallowWrapper {
                               <style__DollarPrice>
                                         1 ETH = 
                                         <style__StyledNumericText
-                                                  type="currency"
+                                                  type="fiat"
                                                   value="412"
                                         />
                               </style__DollarPrice>
@@ -8162,7 +8162,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                                   />
                                         }
@@ -8197,7 +8197,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                                   />
                                         }
@@ -8230,7 +8230,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                                   />
                                         }
@@ -8263,7 +8263,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                                   />
                                         }
@@ -8297,7 +8297,7 @@ ShallowWrapper {
                                                   }
                                                   subtitle={
                                                             <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="41.2"
                                                             />
                                                   }
@@ -8330,7 +8330,7 @@ ShallowWrapper {
                                                   }
                                                   subtitle={
                                                             <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="41.2"
                                                             />
                                                   }
@@ -8489,7 +8489,7 @@ ShallowWrapper {
                             <style__DollarPrice>
                                           1 ETH = 
                                           <style__StyledNumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="412"
                                           />
                             </style__DollarPrice>
@@ -8527,7 +8527,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="0"
                                                         />
                                           }
@@ -8562,7 +8562,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="2.472"
                                                         />
                                           }
@@ -8595,7 +8595,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="81.962044"
                                                         />
                                           }
@@ -8628,7 +8628,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="79.490044"
                                                         />
                                           }
@@ -8662,7 +8662,7 @@ ShallowWrapper {
                                                         }
                                                         subtitle={
                                                                       <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="41.2"
                                                                       />
                                                         }
@@ -8695,7 +8695,7 @@ ShallowWrapper {
                                                         }
                                                         subtitle={
                                                                       <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="41.2"
                                                                       />
                                                         }
@@ -8851,7 +8851,7 @@ ShallowWrapper {
                 <style__DollarPrice>
                                 1 ETH = 
                                 <style__StyledNumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="412"
                                 />
                 </style__DollarPrice>
@@ -8941,7 +8941,7 @@ ShallowWrapper {
                   <style__DollarPrice>
                     1 ETH = 
                     <style__StyledNumericText
-                                        type="currency"
+                                        type="fiat"
                                         value="412"
                     />
 </style__DollarPrice>,
@@ -9122,7 +9122,7 @@ ShallowWrapper {
                     "children": Array [
                       "1 ETH = ",
                       <style__StyledNumericText
-                        type="currency"
+                        type="fiat"
                         value="412"
 />,
                     ],
@@ -9135,7 +9135,7 @@ ShallowWrapper {
                       "key": undefined,
                       "nodeType": "class",
                       "props": Object {
-                        "type": "currency",
+                        "type": "fiat",
                         "value": "412",
                       },
                       "ref": null,
@@ -9181,7 +9181,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="0"
                                                       />
                                     }
@@ -9216,7 +9216,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="2.472"
                                                       />
                                     }
@@ -9249,7 +9249,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="81.962044"
                                                       />
                                     }
@@ -9282,7 +9282,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="79.490044"
                                                       />
                                     }
@@ -9316,7 +9316,7 @@ ShallowWrapper {
                                                       }
                                                       subtitle={
                                                                         <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="41.2"
                                                                         />
                                                       }
@@ -9349,7 +9349,7 @@ ShallowWrapper {
                                                       }
                                                       subtitle={
                                                                         <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="41.2"
                                                                         />
                                                       }
@@ -9469,7 +9469,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                         />
                     }
@@ -9491,7 +9491,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="0"
 />,
                   },
@@ -9565,7 +9565,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                         />
                     }
@@ -9587,7 +9587,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="2.472"
 />,
                   },
@@ -9652,7 +9652,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                         />
                     }
@@ -9674,7 +9674,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="81.962044"
 />,
                   },
@@ -9739,7 +9739,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                         />
                     }
@@ -9761,7 +9761,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="79.490044"
 />,
                   },
@@ -9804,7 +9804,7 @@ ShallowWrapper {
                                             }
                                             subtitle={
                                                                   <NumericText
-                                                                                        type="currency"
+                                                                                        type="fiat"
                                                                                         value="41.2"
                                                                   />
                                             }
@@ -9837,7 +9837,7 @@ ShallowWrapper {
                                             }
                                             subtitle={
                                                                   <NumericText
-                                                                                        type="currency"
+                                                                                        type="fiat"
                                                                                         value="41.2"
                                                                   />
                                             }
@@ -9902,7 +9902,7 @@ ShallowWrapper {
                         }
                         subtitle={
                                                 <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                 />
                         }
@@ -9924,7 +9924,7 @@ ShallowWrapper {
                           ETH
 </SelectableText>,
                         "subtitle": <NumericText
-                          type="currency"
+                          type="fiat"
                           value="41.2"
 />,
                       },
@@ -9989,7 +9989,7 @@ ShallowWrapper {
                         }
                         subtitle={
                                                 <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                 />
                         }
@@ -10011,7 +10011,7 @@ ShallowWrapper {
                           ETH
 </SelectableText>,
                         "subtitle": <NumericText
-                          type="currency"
+                          type="fiat"
                           value="41.2"
 />,
                       },
@@ -11013,7 +11013,7 @@ ShallowWrapper {
                         <style__DollarPrice>
                                 1 ETH = 
                                 <style__StyledNumericText
-                                        type="currency"
+                                        type="fiat"
                                         value="412"
                                 />
                         </style__DollarPrice>
@@ -11051,7 +11051,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="0"
                                         />
                                 }
@@ -11086,7 +11086,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="2.472"
                                         />
                                 }
@@ -11119,7 +11119,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="81.962044"
                                         />
                                 }
@@ -11152,7 +11152,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="79.490044"
                                         />
                                 }
@@ -11186,7 +11186,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                 <NumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="41.2"
                                                 />
                                         }
@@ -11219,7 +11219,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                 <NumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="41.2"
                                                 />
                                         }
@@ -11378,7 +11378,7 @@ ShallowWrapper {
                         <style__DollarPrice>
                                     1 ETH = 
                                     <style__StyledNumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="412"
                                     />
                         </style__DollarPrice>
@@ -11416,7 +11416,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                                 />
                                     }
@@ -11451,7 +11451,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                                 />
                                     }
@@ -11484,7 +11484,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                                 />
                                     }
@@ -11517,7 +11517,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                                 />
                                     }
@@ -11551,7 +11551,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                             <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                             />
                                                 }
@@ -11584,7 +11584,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                             <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                             />
                                                 }
@@ -11740,7 +11740,7 @@ ShallowWrapper {
               <style__DollarPrice>
                             1 ETH = 
                             <style__StyledNumericText
-                                          type="currency"
+                                          type="fiat"
                                           value="412"
                             />
               </style__DollarPrice>
@@ -11830,7 +11830,7 @@ ShallowWrapper {
                 <style__DollarPrice>
                   1 ETH = 
                   <style__StyledNumericText
-                                    type="currency"
+                                    type="fiat"
                                     value="412"
                   />
 </style__DollarPrice>,
@@ -12011,7 +12011,7 @@ ShallowWrapper {
                   "children": Array [
                     "1 ETH = ",
                     <style__StyledNumericText
-                      type="currency"
+                      type="fiat"
                       value="412"
 />,
                   ],
@@ -12024,7 +12024,7 @@ ShallowWrapper {
                     "key": undefined,
                     "nodeType": "class",
                     "props": Object {
-                      "type": "currency",
+                      "type": "fiat",
                       "value": "412",
                     },
                     "ref": null,
@@ -12070,7 +12070,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="0"
                                                 />
                                 }
@@ -12105,7 +12105,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="2.472"
                                                 />
                                 }
@@ -12138,7 +12138,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="81.962044"
                                                 />
                                 }
@@ -12171,7 +12171,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="79.490044"
                                                 />
                                 }
@@ -12205,7 +12205,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                 <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                                 />
                                                 }
@@ -12238,7 +12238,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                 <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                                 />
                                                 }
@@ -12358,7 +12358,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="0"
                                     />
                   }
@@ -12380,7 +12380,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="0"
 />,
                 },
@@ -12454,7 +12454,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="2.472"
                                     />
                   }
@@ -12476,7 +12476,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="2.472"
 />,
                 },
@@ -12541,7 +12541,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="81.962044"
                                     />
                   }
@@ -12563,7 +12563,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="81.962044"
 />,
                 },
@@ -12628,7 +12628,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="79.490044"
                                     />
                   }
@@ -12650,7 +12650,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="79.490044"
 />,
                 },
@@ -12693,7 +12693,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                             <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                             />
                                         }
@@ -12726,7 +12726,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                             <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                             />
                                         }
@@ -12791,7 +12791,7 @@ ShallowWrapper {
                       }
                       subtitle={
                                             <NumericText
-                                                                  type="currency"
+                                                                  type="fiat"
                                                                   value="41.2"
                                             />
                       }
@@ -12813,7 +12813,7 @@ ShallowWrapper {
                         ETH
 </SelectableText>,
                       "subtitle": <NumericText
-                        type="currency"
+                        type="fiat"
                         value="41.2"
 />,
                     },
@@ -12878,7 +12878,7 @@ ShallowWrapper {
                       }
                       subtitle={
                                             <NumericText
-                                                                  type="currency"
+                                                                  type="fiat"
                                                                   value="41.2"
                                             />
                       }
@@ -12900,7 +12900,7 @@ ShallowWrapper {
                         ETH
 </SelectableText>,
                       "subtitle": <NumericText
-                        type="currency"
+                        type="fiat"
                         value="41.2"
 />,
                     },
@@ -13272,7 +13272,7 @@ ShallowWrapper {
                               <style__DollarPrice>
                                         1 ETH = 
                                         <style__StyledNumericText
-                                                  type="currency"
+                                                  type="fiat"
                                                   value="412"
                                         />
                               </style__DollarPrice>
@@ -13310,7 +13310,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                                   />
                                         }
@@ -13345,7 +13345,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                                   />
                                         }
@@ -13378,7 +13378,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                                   />
                                         }
@@ -13411,7 +13411,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                                   />
                                         }
@@ -13445,7 +13445,7 @@ ShallowWrapper {
                                                   }
                                                   subtitle={
                                                             <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="41.2"
                                                             />
                                                   }
@@ -13478,7 +13478,7 @@ ShallowWrapper {
                                                   }
                                                   subtitle={
                                                             <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="41.2"
                                                             />
                                                   }
@@ -13637,7 +13637,7 @@ ShallowWrapper {
                             <style__DollarPrice>
                                           1 ETH = 
                                           <style__StyledNumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="412"
                                           />
                             </style__DollarPrice>
@@ -13675,7 +13675,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="0"
                                                         />
                                           }
@@ -13710,7 +13710,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="2.472"
                                                         />
                                           }
@@ -13743,7 +13743,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="81.962044"
                                                         />
                                           }
@@ -13776,7 +13776,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="79.490044"
                                                         />
                                           }
@@ -13810,7 +13810,7 @@ ShallowWrapper {
                                                         }
                                                         subtitle={
                                                                       <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="41.2"
                                                                       />
                                                         }
@@ -13843,7 +13843,7 @@ ShallowWrapper {
                                                         }
                                                         subtitle={
                                                                       <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="41.2"
                                                                       />
                                                         }
@@ -13999,7 +13999,7 @@ ShallowWrapper {
                 <style__DollarPrice>
                                 1 ETH = 
                                 <style__StyledNumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="412"
                                 />
                 </style__DollarPrice>
@@ -14089,7 +14089,7 @@ ShallowWrapper {
                   <style__DollarPrice>
                     1 ETH = 
                     <style__StyledNumericText
-                                        type="currency"
+                                        type="fiat"
                                         value="412"
                     />
 </style__DollarPrice>,
@@ -14270,7 +14270,7 @@ ShallowWrapper {
                     "children": Array [
                       "1 ETH = ",
                       <style__StyledNumericText
-                        type="currency"
+                        type="fiat"
                         value="412"
 />,
                     ],
@@ -14283,7 +14283,7 @@ ShallowWrapper {
                       "key": undefined,
                       "nodeType": "class",
                       "props": Object {
-                        "type": "currency",
+                        "type": "fiat",
                         "value": "412",
                       },
                       "ref": null,
@@ -14329,7 +14329,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="0"
                                                       />
                                     }
@@ -14364,7 +14364,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="2.472"
                                                       />
                                     }
@@ -14397,7 +14397,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="81.962044"
                                                       />
                                     }
@@ -14430,7 +14430,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="79.490044"
                                                       />
                                     }
@@ -14464,7 +14464,7 @@ ShallowWrapper {
                                                       }
                                                       subtitle={
                                                                         <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="41.2"
                                                                         />
                                                       }
@@ -14497,7 +14497,7 @@ ShallowWrapper {
                                                       }
                                                       subtitle={
                                                                         <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="41.2"
                                                                         />
                                                       }
@@ -14617,7 +14617,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                         />
                     }
@@ -14639,7 +14639,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="0"
 />,
                   },
@@ -14713,7 +14713,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                         />
                     }
@@ -14735,7 +14735,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="2.472"
 />,
                   },
@@ -14800,7 +14800,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                         />
                     }
@@ -14822,7 +14822,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="81.962044"
 />,
                   },
@@ -14887,7 +14887,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                         />
                     }
@@ -14909,7 +14909,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="79.490044"
 />,
                   },
@@ -14952,7 +14952,7 @@ ShallowWrapper {
                                             }
                                             subtitle={
                                                                   <NumericText
-                                                                                        type="currency"
+                                                                                        type="fiat"
                                                                                         value="41.2"
                                                                   />
                                             }
@@ -14985,7 +14985,7 @@ ShallowWrapper {
                                             }
                                             subtitle={
                                                                   <NumericText
-                                                                                        type="currency"
+                                                                                        type="fiat"
                                                                                         value="41.2"
                                                                   />
                                             }
@@ -15050,7 +15050,7 @@ ShallowWrapper {
                         }
                         subtitle={
                                                 <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                 />
                         }
@@ -15072,7 +15072,7 @@ ShallowWrapper {
                           ETH
 </SelectableText>,
                         "subtitle": <NumericText
-                          type="currency"
+                          type="fiat"
                           value="41.2"
 />,
                       },
@@ -15137,7 +15137,7 @@ ShallowWrapper {
                         }
                         subtitle={
                                                 <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                 />
                         }
@@ -15159,7 +15159,7 @@ ShallowWrapper {
                           ETH
 </SelectableText>,
                         "subtitle": <NumericText
-                          type="currency"
+                          type="fiat"
                           value="41.2"
 />,
                       },
@@ -16161,7 +16161,7 @@ ShallowWrapper {
                         <style__DollarPrice>
                                 1 ETH = 
                                 <style__StyledNumericText
-                                        type="currency"
+                                        type="fiat"
                                         value="412"
                                 />
                         </style__DollarPrice>
@@ -16199,7 +16199,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="0"
                                         />
                                 }
@@ -16234,7 +16234,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="2.472"
                                         />
                                 }
@@ -16267,7 +16267,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="81.962044"
                                         />
                                 }
@@ -16300,7 +16300,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="79.490044"
                                         />
                                 }
@@ -16334,7 +16334,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                 <NumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="41.2"
                                                 />
                                         }
@@ -16367,7 +16367,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                 <NumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="41.2"
                                                 />
                                         }
@@ -16500,7 +16500,7 @@ ShallowWrapper {
                         <style__DollarPrice>
                                     1 ETH = 
                                     <style__StyledNumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="412"
                                     />
                         </style__DollarPrice>
@@ -16538,7 +16538,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                                 />
                                     }
@@ -16573,7 +16573,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                                 />
                                     }
@@ -16606,7 +16606,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                                 />
                                     }
@@ -16639,7 +16639,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                                 />
                                     }
@@ -16673,7 +16673,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                             <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                             />
                                                 }
@@ -16706,7 +16706,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                             <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                             />
                                                 }
@@ -16836,7 +16836,7 @@ ShallowWrapper {
               <style__DollarPrice>
                             1 ETH = 
                             <style__StyledNumericText
-                                          type="currency"
+                                          type="fiat"
                                           value="412"
                             />
               </style__DollarPrice>
@@ -16926,7 +16926,7 @@ ShallowWrapper {
                 <style__DollarPrice>
                   1 ETH = 
                   <style__StyledNumericText
-                                    type="currency"
+                                    type="fiat"
                                     value="412"
                   />
 </style__DollarPrice>,
@@ -17107,7 +17107,7 @@ ShallowWrapper {
                   "children": Array [
                     "1 ETH = ",
                     <style__StyledNumericText
-                      type="currency"
+                      type="fiat"
                       value="412"
 />,
                   ],
@@ -17120,7 +17120,7 @@ ShallowWrapper {
                     "key": undefined,
                     "nodeType": "class",
                     "props": Object {
-                      "type": "currency",
+                      "type": "fiat",
                       "value": "412",
                     },
                     "ref": null,
@@ -17166,7 +17166,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="0"
                                                 />
                                 }
@@ -17201,7 +17201,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="2.472"
                                                 />
                                 }
@@ -17234,7 +17234,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="81.962044"
                                                 />
                                 }
@@ -17267,7 +17267,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="79.490044"
                                                 />
                                 }
@@ -17301,7 +17301,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                 <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                                 />
                                                 }
@@ -17334,7 +17334,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                 <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                                 />
                                                 }
@@ -17428,7 +17428,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="0"
                                     />
                   }
@@ -17450,7 +17450,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="0"
 />,
                 },
@@ -17524,7 +17524,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="2.472"
                                     />
                   }
@@ -17546,7 +17546,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="2.472"
 />,
                 },
@@ -17611,7 +17611,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="81.962044"
                                     />
                   }
@@ -17633,7 +17633,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="81.962044"
 />,
                 },
@@ -17698,7 +17698,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="79.490044"
                                     />
                   }
@@ -17720,7 +17720,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="79.490044"
 />,
                 },
@@ -17763,7 +17763,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                             <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                             />
                                         }
@@ -17796,7 +17796,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                             <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                             />
                                         }
@@ -17861,7 +17861,7 @@ ShallowWrapper {
                       }
                       subtitle={
                                             <NumericText
-                                                                  type="currency"
+                                                                  type="fiat"
                                                                   value="41.2"
                                             />
                       }
@@ -17883,7 +17883,7 @@ ShallowWrapper {
                         ETH
 </SelectableText>,
                       "subtitle": <NumericText
-                        type="currency"
+                        type="fiat"
                         value="41.2"
 />,
                     },
@@ -17948,7 +17948,7 @@ ShallowWrapper {
                       }
                       subtitle={
                                             <NumericText
-                                                                  type="currency"
+                                                                  type="fiat"
                                                                   value="41.2"
                                             />
                       }
@@ -17970,7 +17970,7 @@ ShallowWrapper {
                         ETH
 </SelectableText>,
                       "subtitle": <NumericText
-                        type="currency"
+                        type="fiat"
                         value="41.2"
 />,
                     },
@@ -18205,7 +18205,7 @@ ShallowWrapper {
                               <style__DollarPrice>
                                         1 ETH = 
                                         <style__StyledNumericText
-                                                  type="currency"
+                                                  type="fiat"
                                                   value="412"
                                         />
                               </style__DollarPrice>
@@ -18243,7 +18243,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                                   />
                                         }
@@ -18278,7 +18278,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                                   />
                                         }
@@ -18311,7 +18311,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                                   />
                                         }
@@ -18344,7 +18344,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                                   />
                                         }
@@ -18378,7 +18378,7 @@ ShallowWrapper {
                                                   }
                                                   subtitle={
                                                             <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="41.2"
                                                             />
                                                   }
@@ -18411,7 +18411,7 @@ ShallowWrapper {
                                                   }
                                                   subtitle={
                                                             <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="41.2"
                                                             />
                                                   }
@@ -18544,7 +18544,7 @@ ShallowWrapper {
                             <style__DollarPrice>
                                           1 ETH = 
                                           <style__StyledNumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="412"
                                           />
                             </style__DollarPrice>
@@ -18582,7 +18582,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="0"
                                                         />
                                           }
@@ -18617,7 +18617,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="2.472"
                                                         />
                                           }
@@ -18650,7 +18650,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="81.962044"
                                                         />
                                           }
@@ -18683,7 +18683,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="79.490044"
                                                         />
                                           }
@@ -18717,7 +18717,7 @@ ShallowWrapper {
                                                         }
                                                         subtitle={
                                                                       <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="41.2"
                                                                       />
                                                         }
@@ -18750,7 +18750,7 @@ ShallowWrapper {
                                                         }
                                                         subtitle={
                                                                       <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="41.2"
                                                                       />
                                                         }
@@ -18880,7 +18880,7 @@ ShallowWrapper {
                 <style__DollarPrice>
                                 1 ETH = 
                                 <style__StyledNumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="412"
                                 />
                 </style__DollarPrice>
@@ -18970,7 +18970,7 @@ ShallowWrapper {
                   <style__DollarPrice>
                     1 ETH = 
                     <style__StyledNumericText
-                                        type="currency"
+                                        type="fiat"
                                         value="412"
                     />
 </style__DollarPrice>,
@@ -19151,7 +19151,7 @@ ShallowWrapper {
                     "children": Array [
                       "1 ETH = ",
                       <style__StyledNumericText
-                        type="currency"
+                        type="fiat"
                         value="412"
 />,
                     ],
@@ -19164,7 +19164,7 @@ ShallowWrapper {
                       "key": undefined,
                       "nodeType": "class",
                       "props": Object {
-                        "type": "currency",
+                        "type": "fiat",
                         "value": "412",
                       },
                       "ref": null,
@@ -19210,7 +19210,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="0"
                                                       />
                                     }
@@ -19245,7 +19245,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="2.472"
                                                       />
                                     }
@@ -19278,7 +19278,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="81.962044"
                                                       />
                                     }
@@ -19311,7 +19311,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="79.490044"
                                                       />
                                     }
@@ -19345,7 +19345,7 @@ ShallowWrapper {
                                                       }
                                                       subtitle={
                                                                         <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="41.2"
                                                                         />
                                                       }
@@ -19378,7 +19378,7 @@ ShallowWrapper {
                                                       }
                                                       subtitle={
                                                                         <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="41.2"
                                                                         />
                                                       }
@@ -19472,7 +19472,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                         />
                     }
@@ -19494,7 +19494,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="0"
 />,
                   },
@@ -19568,7 +19568,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                         />
                     }
@@ -19590,7 +19590,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="2.472"
 />,
                   },
@@ -19655,7 +19655,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                         />
                     }
@@ -19677,7 +19677,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="81.962044"
 />,
                   },
@@ -19742,7 +19742,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                         />
                     }
@@ -19764,7 +19764,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="79.490044"
 />,
                   },
@@ -19807,7 +19807,7 @@ ShallowWrapper {
                                             }
                                             subtitle={
                                                                   <NumericText
-                                                                                        type="currency"
+                                                                                        type="fiat"
                                                                                         value="41.2"
                                                                   />
                                             }
@@ -19840,7 +19840,7 @@ ShallowWrapper {
                                             }
                                             subtitle={
                                                                   <NumericText
-                                                                                        type="currency"
+                                                                                        type="fiat"
                                                                                         value="41.2"
                                                                   />
                                             }
@@ -19905,7 +19905,7 @@ ShallowWrapper {
                         }
                         subtitle={
                                                 <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                 />
                         }
@@ -19927,7 +19927,7 @@ ShallowWrapper {
                           ETH
 </SelectableText>,
                         "subtitle": <NumericText
-                          type="currency"
+                          type="fiat"
                           value="41.2"
 />,
                       },
@@ -19992,7 +19992,7 @@ ShallowWrapper {
                         }
                         subtitle={
                                                 <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                 />
                         }
@@ -20014,7 +20014,7 @@ ShallowWrapper {
                           ETH
 </SelectableText>,
                         "subtitle": <NumericText
-                          type="currency"
+                          type="fiat"
                           value="41.2"
 />,
                       },
@@ -20879,7 +20879,7 @@ ShallowWrapper {
                         <style__DollarPrice>
                                 1 ETH = 
                                 <style__StyledNumericText
-                                        type="currency"
+                                        type="fiat"
                                         value="412"
                                 />
                         </style__DollarPrice>
@@ -20917,7 +20917,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="0"
                                         />
                                 }
@@ -20952,7 +20952,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="2.472"
                                         />
                                 }
@@ -20985,7 +20985,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="81.962044"
                                         />
                                 }
@@ -21018,7 +21018,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="79.490044"
                                         />
                                 }
@@ -21052,7 +21052,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                 <NumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="41.2"
                                                 />
                                         }
@@ -21085,7 +21085,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                 <NumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="41.2"
                                                 />
                                         }
@@ -21218,7 +21218,7 @@ ShallowWrapper {
                         <style__DollarPrice>
                                     1 ETH = 
                                     <style__StyledNumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="412"
                                     />
                         </style__DollarPrice>
@@ -21256,7 +21256,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                                 />
                                     }
@@ -21291,7 +21291,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                                 />
                                     }
@@ -21324,7 +21324,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                                 />
                                     }
@@ -21357,7 +21357,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                                 />
                                     }
@@ -21391,7 +21391,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                             <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                             />
                                                 }
@@ -21424,7 +21424,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                             <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                             />
                                                 }
@@ -21554,7 +21554,7 @@ ShallowWrapper {
               <style__DollarPrice>
                             1 ETH = 
                             <style__StyledNumericText
-                                          type="currency"
+                                          type="fiat"
                                           value="412"
                             />
               </style__DollarPrice>
@@ -21644,7 +21644,7 @@ ShallowWrapper {
                 <style__DollarPrice>
                   1 ETH = 
                   <style__StyledNumericText
-                                    type="currency"
+                                    type="fiat"
                                     value="412"
                   />
 </style__DollarPrice>,
@@ -21825,7 +21825,7 @@ ShallowWrapper {
                   "children": Array [
                     "1 ETH = ",
                     <style__StyledNumericText
-                      type="currency"
+                      type="fiat"
                       value="412"
 />,
                   ],
@@ -21838,7 +21838,7 @@ ShallowWrapper {
                     "key": undefined,
                     "nodeType": "class",
                     "props": Object {
-                      "type": "currency",
+                      "type": "fiat",
                       "value": "412",
                     },
                     "ref": null,
@@ -21884,7 +21884,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="0"
                                                 />
                                 }
@@ -21919,7 +21919,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="2.472"
                                                 />
                                 }
@@ -21952,7 +21952,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="81.962044"
                                                 />
                                 }
@@ -21985,7 +21985,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="79.490044"
                                                 />
                                 }
@@ -22019,7 +22019,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                 <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                                 />
                                                 }
@@ -22052,7 +22052,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                 <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                                 />
                                                 }
@@ -22146,7 +22146,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="0"
                                     />
                   }
@@ -22168,7 +22168,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="0"
 />,
                 },
@@ -22242,7 +22242,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="2.472"
                                     />
                   }
@@ -22264,7 +22264,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="2.472"
 />,
                 },
@@ -22329,7 +22329,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="81.962044"
                                     />
                   }
@@ -22351,7 +22351,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="81.962044"
 />,
                 },
@@ -22416,7 +22416,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="79.490044"
                                     />
                   }
@@ -22438,7 +22438,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="79.490044"
 />,
                 },
@@ -22481,7 +22481,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                             <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                             />
                                         }
@@ -22514,7 +22514,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                             <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                             />
                                         }
@@ -22579,7 +22579,7 @@ ShallowWrapper {
                       }
                       subtitle={
                                             <NumericText
-                                                                  type="currency"
+                                                                  type="fiat"
                                                                   value="41.2"
                                             />
                       }
@@ -22601,7 +22601,7 @@ ShallowWrapper {
                         ETH
 </SelectableText>,
                       "subtitle": <NumericText
-                        type="currency"
+                        type="fiat"
                         value="41.2"
 />,
                     },
@@ -22666,7 +22666,7 @@ ShallowWrapper {
                       }
                       subtitle={
                                             <NumericText
-                                                                  type="currency"
+                                                                  type="fiat"
                                                                   value="41.2"
                                             />
                       }
@@ -22688,7 +22688,7 @@ ShallowWrapper {
                         ETH
 </SelectableText>,
                       "subtitle": <NumericText
-                        type="currency"
+                        type="fiat"
                         value="41.2"
 />,
                     },
@@ -22923,7 +22923,7 @@ ShallowWrapper {
                               <style__DollarPrice>
                                         1 ETH = 
                                         <style__StyledNumericText
-                                                  type="currency"
+                                                  type="fiat"
                                                   value="412"
                                         />
                               </style__DollarPrice>
@@ -22961,7 +22961,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                                   />
                                         }
@@ -22996,7 +22996,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                                   />
                                         }
@@ -23029,7 +23029,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                                   />
                                         }
@@ -23062,7 +23062,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                                   />
                                         }
@@ -23096,7 +23096,7 @@ ShallowWrapper {
                                                   }
                                                   subtitle={
                                                             <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="41.2"
                                                             />
                                                   }
@@ -23129,7 +23129,7 @@ ShallowWrapper {
                                                   }
                                                   subtitle={
                                                             <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="41.2"
                                                             />
                                                   }
@@ -23262,7 +23262,7 @@ ShallowWrapper {
                             <style__DollarPrice>
                                           1 ETH = 
                                           <style__StyledNumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="412"
                                           />
                             </style__DollarPrice>
@@ -23300,7 +23300,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="0"
                                                         />
                                           }
@@ -23335,7 +23335,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="2.472"
                                                         />
                                           }
@@ -23368,7 +23368,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="81.962044"
                                                         />
                                           }
@@ -23401,7 +23401,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="79.490044"
                                                         />
                                           }
@@ -23435,7 +23435,7 @@ ShallowWrapper {
                                                         }
                                                         subtitle={
                                                                       <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="41.2"
                                                                       />
                                                         }
@@ -23468,7 +23468,7 @@ ShallowWrapper {
                                                         }
                                                         subtitle={
                                                                       <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="41.2"
                                                                       />
                                                         }
@@ -23598,7 +23598,7 @@ ShallowWrapper {
                 <style__DollarPrice>
                                 1 ETH = 
                                 <style__StyledNumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="412"
                                 />
                 </style__DollarPrice>
@@ -23688,7 +23688,7 @@ ShallowWrapper {
                   <style__DollarPrice>
                     1 ETH = 
                     <style__StyledNumericText
-                                        type="currency"
+                                        type="fiat"
                                         value="412"
                     />
 </style__DollarPrice>,
@@ -23869,7 +23869,7 @@ ShallowWrapper {
                     "children": Array [
                       "1 ETH = ",
                       <style__StyledNumericText
-                        type="currency"
+                        type="fiat"
                         value="412"
 />,
                     ],
@@ -23882,7 +23882,7 @@ ShallowWrapper {
                       "key": undefined,
                       "nodeType": "class",
                       "props": Object {
-                        "type": "currency",
+                        "type": "fiat",
                         "value": "412",
                       },
                       "ref": null,
@@ -23928,7 +23928,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="0"
                                                       />
                                     }
@@ -23963,7 +23963,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="2.472"
                                                       />
                                     }
@@ -23996,7 +23996,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="81.962044"
                                                       />
                                     }
@@ -24029,7 +24029,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="79.490044"
                                                       />
                                     }
@@ -24063,7 +24063,7 @@ ShallowWrapper {
                                                       }
                                                       subtitle={
                                                                         <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="41.2"
                                                                         />
                                                       }
@@ -24096,7 +24096,7 @@ ShallowWrapper {
                                                       }
                                                       subtitle={
                                                                         <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="41.2"
                                                                         />
                                                       }
@@ -24190,7 +24190,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                         />
                     }
@@ -24212,7 +24212,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="0"
 />,
                   },
@@ -24286,7 +24286,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                         />
                     }
@@ -24308,7 +24308,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="2.472"
 />,
                   },
@@ -24373,7 +24373,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                         />
                     }
@@ -24395,7 +24395,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="81.962044"
 />,
                   },
@@ -24460,7 +24460,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                         />
                     }
@@ -24482,7 +24482,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="79.490044"
 />,
                   },
@@ -24525,7 +24525,7 @@ ShallowWrapper {
                                             }
                                             subtitle={
                                                                   <NumericText
-                                                                                        type="currency"
+                                                                                        type="fiat"
                                                                                         value="41.2"
                                                                   />
                                             }
@@ -24558,7 +24558,7 @@ ShallowWrapper {
                                             }
                                             subtitle={
                                                                   <NumericText
-                                                                                        type="currency"
+                                                                                        type="fiat"
                                                                                         value="41.2"
                                                                   />
                                             }
@@ -24623,7 +24623,7 @@ ShallowWrapper {
                         }
                         subtitle={
                                                 <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                 />
                         }
@@ -24645,7 +24645,7 @@ ShallowWrapper {
                           ETH
 </SelectableText>,
                         "subtitle": <NumericText
-                          type="currency"
+                          type="fiat"
                           value="41.2"
 />,
                       },
@@ -24710,7 +24710,7 @@ ShallowWrapper {
                         }
                         subtitle={
                                                 <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                 />
                         }
@@ -24732,7 +24732,7 @@ ShallowWrapper {
                           ETH
 </SelectableText>,
                         "subtitle": <NumericText
-                          type="currency"
+                          type="fiat"
                           value="41.2"
 />,
                       },
@@ -25598,7 +25598,7 @@ ShallowWrapper {
                         <style__DollarPrice>
                                 1 ETH = 
                                 <style__StyledNumericText
-                                        type="currency"
+                                        type="fiat"
                                         value="412"
                                 />
                         </style__DollarPrice>
@@ -25636,7 +25636,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="0"
                                         />
                                 }
@@ -25671,7 +25671,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="2.472"
                                         />
                                 }
@@ -25704,7 +25704,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="81.962044"
                                         />
                                 }
@@ -25737,7 +25737,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="79.490044"
                                         />
                                 }
@@ -25771,7 +25771,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                 <NumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="41.2"
                                                 />
                                         }
@@ -25804,7 +25804,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                 <NumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="41.2"
                                                 />
                                         }
@@ -25937,7 +25937,7 @@ ShallowWrapper {
                         <style__DollarPrice>
                                     1 ETH = 
                                     <style__StyledNumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="412"
                                     />
                         </style__DollarPrice>
@@ -25975,7 +25975,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                                 />
                                     }
@@ -26010,7 +26010,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                                 />
                                     }
@@ -26043,7 +26043,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                                 />
                                     }
@@ -26076,7 +26076,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                                 />
                                     }
@@ -26110,7 +26110,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                             <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                             />
                                                 }
@@ -26143,7 +26143,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                             <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                             />
                                                 }
@@ -26273,7 +26273,7 @@ ShallowWrapper {
               <style__DollarPrice>
                             1 ETH = 
                             <style__StyledNumericText
-                                          type="currency"
+                                          type="fiat"
                                           value="412"
                             />
               </style__DollarPrice>
@@ -26363,7 +26363,7 @@ ShallowWrapper {
                 <style__DollarPrice>
                   1 ETH = 
                   <style__StyledNumericText
-                                    type="currency"
+                                    type="fiat"
                                     value="412"
                   />
 </style__DollarPrice>,
@@ -26544,7 +26544,7 @@ ShallowWrapper {
                   "children": Array [
                     "1 ETH = ",
                     <style__StyledNumericText
-                      type="currency"
+                      type="fiat"
                       value="412"
 />,
                   ],
@@ -26557,7 +26557,7 @@ ShallowWrapper {
                     "key": undefined,
                     "nodeType": "class",
                     "props": Object {
-                      "type": "currency",
+                      "type": "fiat",
                       "value": "412",
                     },
                     "ref": null,
@@ -26603,7 +26603,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="0"
                                                 />
                                 }
@@ -26638,7 +26638,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="2.472"
                                                 />
                                 }
@@ -26671,7 +26671,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="81.962044"
                                                 />
                                 }
@@ -26704,7 +26704,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="79.490044"
                                                 />
                                 }
@@ -26738,7 +26738,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                 <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                                 />
                                                 }
@@ -26771,7 +26771,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                 <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                                 />
                                                 }
@@ -26865,7 +26865,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="0"
                                     />
                   }
@@ -26887,7 +26887,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="0"
 />,
                 },
@@ -26961,7 +26961,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="2.472"
                                     />
                   }
@@ -26983,7 +26983,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="2.472"
 />,
                 },
@@ -27048,7 +27048,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="81.962044"
                                     />
                   }
@@ -27070,7 +27070,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="81.962044"
 />,
                 },
@@ -27135,7 +27135,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="79.490044"
                                     />
                   }
@@ -27157,7 +27157,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="79.490044"
 />,
                 },
@@ -27200,7 +27200,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                             <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                             />
                                         }
@@ -27233,7 +27233,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                             <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                             />
                                         }
@@ -27298,7 +27298,7 @@ ShallowWrapper {
                       }
                       subtitle={
                                             <NumericText
-                                                                  type="currency"
+                                                                  type="fiat"
                                                                   value="41.2"
                                             />
                       }
@@ -27320,7 +27320,7 @@ ShallowWrapper {
                         ETH
 </SelectableText>,
                       "subtitle": <NumericText
-                        type="currency"
+                        type="fiat"
                         value="41.2"
 />,
                     },
@@ -27385,7 +27385,7 @@ ShallowWrapper {
                       }
                       subtitle={
                                             <NumericText
-                                                                  type="currency"
+                                                                  type="fiat"
                                                                   value="41.2"
                                             />
                       }
@@ -27407,7 +27407,7 @@ ShallowWrapper {
                         ETH
 </SelectableText>,
                       "subtitle": <NumericText
-                        type="currency"
+                        type="fiat"
                         value="41.2"
 />,
                     },
@@ -27642,7 +27642,7 @@ ShallowWrapper {
                               <style__DollarPrice>
                                         1 ETH = 
                                         <style__StyledNumericText
-                                                  type="currency"
+                                                  type="fiat"
                                                   value="412"
                                         />
                               </style__DollarPrice>
@@ -27680,7 +27680,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                                   />
                                         }
@@ -27715,7 +27715,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                                   />
                                         }
@@ -27748,7 +27748,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                                   />
                                         }
@@ -27781,7 +27781,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                                   />
                                         }
@@ -27815,7 +27815,7 @@ ShallowWrapper {
                                                   }
                                                   subtitle={
                                                             <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="41.2"
                                                             />
                                                   }
@@ -27848,7 +27848,7 @@ ShallowWrapper {
                                                   }
                                                   subtitle={
                                                             <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="41.2"
                                                             />
                                                   }
@@ -27981,7 +27981,7 @@ ShallowWrapper {
                             <style__DollarPrice>
                                           1 ETH = 
                                           <style__StyledNumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="412"
                                           />
                             </style__DollarPrice>
@@ -28019,7 +28019,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="0"
                                                         />
                                           }
@@ -28054,7 +28054,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="2.472"
                                                         />
                                           }
@@ -28087,7 +28087,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="81.962044"
                                                         />
                                           }
@@ -28120,7 +28120,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="79.490044"
                                                         />
                                           }
@@ -28154,7 +28154,7 @@ ShallowWrapper {
                                                         }
                                                         subtitle={
                                                                       <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="41.2"
                                                                       />
                                                         }
@@ -28187,7 +28187,7 @@ ShallowWrapper {
                                                         }
                                                         subtitle={
                                                                       <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="41.2"
                                                                       />
                                                         }
@@ -28317,7 +28317,7 @@ ShallowWrapper {
                 <style__DollarPrice>
                                 1 ETH = 
                                 <style__StyledNumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="412"
                                 />
                 </style__DollarPrice>
@@ -28407,7 +28407,7 @@ ShallowWrapper {
                   <style__DollarPrice>
                     1 ETH = 
                     <style__StyledNumericText
-                                        type="currency"
+                                        type="fiat"
                                         value="412"
                     />
 </style__DollarPrice>,
@@ -28588,7 +28588,7 @@ ShallowWrapper {
                     "children": Array [
                       "1 ETH = ",
                       <style__StyledNumericText
-                        type="currency"
+                        type="fiat"
                         value="412"
 />,
                     ],
@@ -28601,7 +28601,7 @@ ShallowWrapper {
                       "key": undefined,
                       "nodeType": "class",
                       "props": Object {
-                        "type": "currency",
+                        "type": "fiat",
                         "value": "412",
                       },
                       "ref": null,
@@ -28647,7 +28647,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="0"
                                                       />
                                     }
@@ -28682,7 +28682,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="2.472"
                                                       />
                                     }
@@ -28715,7 +28715,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="81.962044"
                                                       />
                                     }
@@ -28748,7 +28748,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="79.490044"
                                                       />
                                     }
@@ -28782,7 +28782,7 @@ ShallowWrapper {
                                                       }
                                                       subtitle={
                                                                         <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="41.2"
                                                                         />
                                                       }
@@ -28815,7 +28815,7 @@ ShallowWrapper {
                                                       }
                                                       subtitle={
                                                                         <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="41.2"
                                                                         />
                                                       }
@@ -28909,7 +28909,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                         />
                     }
@@ -28931,7 +28931,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="0"
 />,
                   },
@@ -29005,7 +29005,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                         />
                     }
@@ -29027,7 +29027,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="2.472"
 />,
                   },
@@ -29092,7 +29092,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                         />
                     }
@@ -29114,7 +29114,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="81.962044"
 />,
                   },
@@ -29179,7 +29179,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                         />
                     }
@@ -29201,7 +29201,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="79.490044"
 />,
                   },
@@ -29244,7 +29244,7 @@ ShallowWrapper {
                                             }
                                             subtitle={
                                                                   <NumericText
-                                                                                        type="currency"
+                                                                                        type="fiat"
                                                                                         value="41.2"
                                                                   />
                                             }
@@ -29277,7 +29277,7 @@ ShallowWrapper {
                                             }
                                             subtitle={
                                                                   <NumericText
-                                                                                        type="currency"
+                                                                                        type="fiat"
                                                                                         value="41.2"
                                                                   />
                                             }
@@ -29342,7 +29342,7 @@ ShallowWrapper {
                         }
                         subtitle={
                                                 <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                 />
                         }
@@ -29364,7 +29364,7 @@ ShallowWrapper {
                           ETH
 </SelectableText>,
                         "subtitle": <NumericText
-                          type="currency"
+                          type="fiat"
                           value="41.2"
 />,
                       },
@@ -29429,7 +29429,7 @@ ShallowWrapper {
                         }
                         subtitle={
                                                 <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                 />
                         }
@@ -29451,7 +29451,7 @@ ShallowWrapper {
                           ETH
 </SelectableText>,
                         "subtitle": <NumericText
-                          type="currency"
+                          type="fiat"
                           value="41.2"
 />,
                       },
@@ -32834,7 +32834,7 @@ ShallowWrapper {
                         <style__DollarPrice>
                                 1 ETH = 
                                 <style__StyledNumericText
-                                        type="currency"
+                                        type="fiat"
                                         value="412"
                                 />
                         </style__DollarPrice>
@@ -32872,7 +32872,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="0"
                                         />
                                 }
@@ -32907,7 +32907,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="2.472"
                                         />
                                 }
@@ -32940,7 +32940,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="81.962044"
                                         />
                                 }
@@ -32973,7 +32973,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                         <NumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="79.490044"
                                         />
                                 }
@@ -33007,7 +33007,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                 <NumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="41.2"
                                                 />
                                         }
@@ -33040,7 +33040,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                 <NumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="41.2"
                                                 />
                                         }
@@ -33173,7 +33173,7 @@ ShallowWrapper {
                         <style__DollarPrice>
                                     1 ETH = 
                                     <style__StyledNumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="412"
                                     />
                         </style__DollarPrice>
@@ -33211,7 +33211,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                                 />
                                     }
@@ -33246,7 +33246,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                                 />
                                     }
@@ -33279,7 +33279,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                                 />
                                     }
@@ -33312,7 +33312,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                 <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                                 />
                                     }
@@ -33346,7 +33346,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                             <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                             />
                                                 }
@@ -33379,7 +33379,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                             <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                             />
                                                 }
@@ -33509,7 +33509,7 @@ ShallowWrapper {
               <style__DollarPrice>
                             1 ETH = 
                             <style__StyledNumericText
-                                          type="currency"
+                                          type="fiat"
                                           value="412"
                             />
               </style__DollarPrice>
@@ -33599,7 +33599,7 @@ ShallowWrapper {
                 <style__DollarPrice>
                   1 ETH = 
                   <style__StyledNumericText
-                                    type="currency"
+                                    type="fiat"
                                     value="412"
                   />
 </style__DollarPrice>,
@@ -33780,7 +33780,7 @@ ShallowWrapper {
                   "children": Array [
                     "1 ETH = ",
                     <style__StyledNumericText
-                      type="currency"
+                      type="fiat"
                       value="412"
 />,
                   ],
@@ -33793,7 +33793,7 @@ ShallowWrapper {
                     "key": undefined,
                     "nodeType": "class",
                     "props": Object {
-                      "type": "currency",
+                      "type": "fiat",
                       "value": "412",
                     },
                     "ref": null,
@@ -33839,7 +33839,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="0"
                                                 />
                                 }
@@ -33874,7 +33874,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="2.472"
                                                 />
                                 }
@@ -33907,7 +33907,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="81.962044"
                                                 />
                                 }
@@ -33940,7 +33940,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                 <NumericText
-                                                                type="currency"
+                                                                type="fiat"
                                                                 value="79.490044"
                                                 />
                                 }
@@ -33974,7 +33974,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                 <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                                 />
                                                 }
@@ -34007,7 +34007,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                 <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                                 />
                                                 }
@@ -34101,7 +34101,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="0"
                                     />
                   }
@@ -34123,7 +34123,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="0"
 />,
                 },
@@ -34197,7 +34197,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="2.472"
                                     />
                   }
@@ -34219,7 +34219,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="2.472"
 />,
                 },
@@ -34284,7 +34284,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="81.962044"
                                     />
                   }
@@ -34306,7 +34306,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="81.962044"
 />,
                 },
@@ -34371,7 +34371,7 @@ ShallowWrapper {
                   }
                   subtitle={
                                     <NumericText
-                                                      type="currency"
+                                                      type="fiat"
                                                       value="79.490044"
                                     />
                   }
@@ -34393,7 +34393,7 @@ ShallowWrapper {
                     ETH
 </SelectableText>,
                   "subtitle": <NumericText
-                    type="currency"
+                    type="fiat"
                     value="79.490044"
 />,
                 },
@@ -34436,7 +34436,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                             <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                             />
                                         }
@@ -34469,7 +34469,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                             <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="41.2"
                                                             />
                                         }
@@ -34534,7 +34534,7 @@ ShallowWrapper {
                       }
                       subtitle={
                                             <NumericText
-                                                                  type="currency"
+                                                                  type="fiat"
                                                                   value="41.2"
                                             />
                       }
@@ -34556,7 +34556,7 @@ ShallowWrapper {
                         ETH
 </SelectableText>,
                       "subtitle": <NumericText
-                        type="currency"
+                        type="fiat"
                         value="41.2"
 />,
                     },
@@ -34621,7 +34621,7 @@ ShallowWrapper {
                       }
                       subtitle={
                                             <NumericText
-                                                                  type="currency"
+                                                                  type="fiat"
                                                                   value="41.2"
                                             />
                       }
@@ -34643,7 +34643,7 @@ ShallowWrapper {
                         ETH
 </SelectableText>,
                       "subtitle": <NumericText
-                        type="currency"
+                        type="fiat"
                         value="41.2"
 />,
                     },
@@ -34878,7 +34878,7 @@ ShallowWrapper {
                               <style__DollarPrice>
                                         1 ETH = 
                                         <style__StyledNumericText
-                                                  type="currency"
+                                                  type="fiat"
                                                   value="412"
                                         />
                               </style__DollarPrice>
@@ -34916,7 +34916,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                                   />
                                         }
@@ -34951,7 +34951,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                                   />
                                         }
@@ -34984,7 +34984,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                                   />
                                         }
@@ -35017,7 +35017,7 @@ ShallowWrapper {
                                         }
                                         subtitle={
                                                   <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                                   />
                                         }
@@ -35051,7 +35051,7 @@ ShallowWrapper {
                                                   }
                                                   subtitle={
                                                             <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="41.2"
                                                             />
                                                   }
@@ -35084,7 +35084,7 @@ ShallowWrapper {
                                                   }
                                                   subtitle={
                                                             <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="41.2"
                                                             />
                                                   }
@@ -35217,7 +35217,7 @@ ShallowWrapper {
                             <style__DollarPrice>
                                           1 ETH = 
                                           <style__StyledNumericText
-                                                        type="currency"
+                                                        type="fiat"
                                                         value="412"
                                           />
                             </style__DollarPrice>
@@ -35255,7 +35255,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="0"
                                                         />
                                           }
@@ -35290,7 +35290,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="2.472"
                                                         />
                                           }
@@ -35323,7 +35323,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="81.962044"
                                                         />
                                           }
@@ -35356,7 +35356,7 @@ ShallowWrapper {
                                           }
                                           subtitle={
                                                         <NumericText
-                                                                      type="currency"
+                                                                      type="fiat"
                                                                       value="79.490044"
                                                         />
                                           }
@@ -35390,7 +35390,7 @@ ShallowWrapper {
                                                         }
                                                         subtitle={
                                                                       <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="41.2"
                                                                       />
                                                         }
@@ -35423,7 +35423,7 @@ ShallowWrapper {
                                                         }
                                                         subtitle={
                                                                       <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="41.2"
                                                                       />
                                                         }
@@ -35553,7 +35553,7 @@ ShallowWrapper {
                 <style__DollarPrice>
                                 1 ETH = 
                                 <style__StyledNumericText
-                                                type="currency"
+                                                type="fiat"
                                                 value="412"
                                 />
                 </style__DollarPrice>
@@ -35643,7 +35643,7 @@ ShallowWrapper {
                   <style__DollarPrice>
                     1 ETH = 
                     <style__StyledNumericText
-                                        type="currency"
+                                        type="fiat"
                                         value="412"
                     />
 </style__DollarPrice>,
@@ -35824,7 +35824,7 @@ ShallowWrapper {
                     "children": Array [
                       "1 ETH = ",
                       <style__StyledNumericText
-                        type="currency"
+                        type="fiat"
                         value="412"
 />,
                     ],
@@ -35837,7 +35837,7 @@ ShallowWrapper {
                       "key": undefined,
                       "nodeType": "class",
                       "props": Object {
-                        "type": "currency",
+                        "type": "fiat",
                         "value": "412",
                       },
                       "ref": null,
@@ -35883,7 +35883,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="0"
                                                       />
                                     }
@@ -35918,7 +35918,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="2.472"
                                                       />
                                     }
@@ -35951,7 +35951,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="81.962044"
                                                       />
                                     }
@@ -35984,7 +35984,7 @@ ShallowWrapper {
                                     }
                                     subtitle={
                                                       <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="79.490044"
                                                       />
                                     }
@@ -36018,7 +36018,7 @@ ShallowWrapper {
                                                       }
                                                       subtitle={
                                                                         <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="41.2"
                                                                         />
                                                       }
@@ -36051,7 +36051,7 @@ ShallowWrapper {
                                                       }
                                                       subtitle={
                                                                         <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="41.2"
                                                                         />
                                                       }
@@ -36145,7 +36145,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="0"
                                         />
                     }
@@ -36167,7 +36167,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="0"
 />,
                   },
@@ -36241,7 +36241,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="2.472"
                                         />
                     }
@@ -36263,7 +36263,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="2.472"
 />,
                   },
@@ -36328,7 +36328,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="81.962044"
                                         />
                     }
@@ -36350,7 +36350,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="81.962044"
 />,
                   },
@@ -36415,7 +36415,7 @@ ShallowWrapper {
                     }
                     subtitle={
                                         <NumericText
-                                                            type="currency"
+                                                            type="fiat"
                                                             value="79.490044"
                                         />
                     }
@@ -36437,7 +36437,7 @@ ShallowWrapper {
                       ETH
 </SelectableText>,
                     "subtitle": <NumericText
-                      type="currency"
+                      type="fiat"
                       value="79.490044"
 />,
                   },
@@ -36480,7 +36480,7 @@ ShallowWrapper {
                                             }
                                             subtitle={
                                                                   <NumericText
-                                                                                        type="currency"
+                                                                                        type="fiat"
                                                                                         value="41.2"
                                                                   />
                                             }
@@ -36513,7 +36513,7 @@ ShallowWrapper {
                                             }
                                             subtitle={
                                                                   <NumericText
-                                                                                        type="currency"
+                                                                                        type="fiat"
                                                                                         value="41.2"
                                                                   />
                                             }
@@ -36578,7 +36578,7 @@ ShallowWrapper {
                         }
                         subtitle={
                                                 <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                 />
                         }
@@ -36600,7 +36600,7 @@ ShallowWrapper {
                           ETH
 </SelectableText>,
                         "subtitle": <NumericText
-                          type="currency"
+                          type="fiat"
                           value="41.2"
 />,
                       },
@@ -36665,7 +36665,7 @@ ShallowWrapper {
                         }
                         subtitle={
                                                 <NumericText
-                                                                        type="currency"
+                                                                        type="fiat"
                                                                         value="41.2"
                                                 />
                         }
@@ -36687,7 +36687,7 @@ ShallowWrapper {
                           ETH
 </SelectableText>,
                         "subtitle": <NumericText
-                          type="currency"
+                          type="fiat"
                           value="41.2"
 />,
                       },

--- a/src/containers/NahmiiDeposit/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/NahmiiDeposit/tests/__snapshots__/index.test.js.snap
@@ -496,6 +496,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -708,6 +709,7 @@ ShallowWrapper {
                                 intl={
                                         Object {
                                                 "formatMessage": [Function],
+                                                "formatNumber": [Function],
                                               }
                                 }
                                 onChange={[Function]}
@@ -744,6 +746,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0"
                                                 />
                                                  
@@ -778,6 +781,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.006"
                                                 />
                                                  
@@ -810,6 +814,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.198937"
                                                 />
                                                  
@@ -842,6 +847,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.192937"
                                                 />
                                                  
@@ -875,6 +881,7 @@ ShallowWrapper {
                                         main={
                                                 <SelectableText>
                                                         <NumericText
+                                                                maxDecimalPlaces={18}
                                                                 value="0.1"
                                                         />
                                                          
@@ -907,6 +914,7 @@ ShallowWrapper {
                                         main={
                                                 <SelectableText>
                                                         <NumericText
+                                                                maxDecimalPlaces={18}
                                                                 value="0.1"
                                                         />
                                                          
@@ -1066,6 +1074,7 @@ ShallowWrapper {
                                     intl={
                                                 Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                                     }
                                     onChange={[Function]}
@@ -1102,6 +1111,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0"
                                                             />
                                                              
@@ -1136,6 +1146,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.006"
                                                             />
                                                              
@@ -1168,6 +1179,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.198937"
                                                             />
                                                              
@@ -1200,6 +1212,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.192937"
                                                             />
                                                              
@@ -1233,6 +1246,7 @@ ShallowWrapper {
                                                 main={
                                                             <SelectableText>
                                                                         <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.1"
                                                                         />
                                                                          
@@ -1265,6 +1279,7 @@ ShallowWrapper {
                                                 main={
                                                             <SelectableText>
                                                                         <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.1"
                                                                         />
                                                                          
@@ -1421,6 +1436,7 @@ ShallowWrapper {
                             intl={
                                           Object {
                                                         "formatMessage": [Function],
+                                                        "formatNumber": [Function],
                                                       }
                             }
                             onChange={[Function]}
@@ -1510,6 +1526,7 @@ ShallowWrapper {
                   intl={
                                     Object {
                                                       "formatMessage": [Function],
+                                                      "formatNumber": [Function],
                                                     }
                   }
                   onChange={[Function]}
@@ -1682,6 +1699,7 @@ ShallowWrapper {
                   "gasStatistics": undefined,
                   "intl": Object {
                     "formatMessage": [Function],
+                    "formatNumber": [Function],
                   },
                   "onChange": [Function],
                 },
@@ -1747,6 +1765,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0"
                                                                 />
                                                                  
@@ -1781,6 +1800,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.006"
                                                                 />
                                                                  
@@ -1813,6 +1833,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.198937"
                                                                 />
                                                                  
@@ -1845,6 +1866,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.192937"
                                                                 />
                                                                  
@@ -1878,6 +1900,7 @@ ShallowWrapper {
                                                 main={
                                                                 <SelectableText>
                                                                                 <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                                 />
                                                                                  
@@ -1910,6 +1933,7 @@ ShallowWrapper {
                                                 main={
                                                                 <SelectableText>
                                                                                 <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                                 />
                                                                                  
@@ -2029,6 +2053,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0"
                                                       />
                                                        
@@ -2052,6 +2077,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0"
                     />
                      
@@ -2123,6 +2149,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.006"
                                                       />
                                                        
@@ -2146,6 +2173,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.006"
                     />
                      
@@ -2208,6 +2236,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.198937"
                                                       />
                                                        
@@ -2231,6 +2260,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.198937"
                     />
                      
@@ -2293,6 +2323,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.192937"
                                                       />
                                                        
@@ -2316,6 +2347,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.192937"
                     />
                      
@@ -2356,6 +2388,7 @@ ShallowWrapper {
                                         main={
                                                             <SelectableText>
                                                                                 <NumericText
+                                                                                                    maxDecimalPlaces={18}
                                                                                                     value="0.1"
                                                                                 />
                                                                                  
@@ -2388,6 +2421,7 @@ ShallowWrapper {
                                         main={
                                                             <SelectableText>
                                                                                 <NumericText
+                                                                                                    maxDecimalPlaces={18}
                                                                                                     value="0.1"
                                                                                 />
                                                                                  
@@ -2452,6 +2486,7 @@ ShallowWrapper {
                       main={
                                             <SelectableText>
                                                                   <NumericText
+                                                                                        maxDecimalPlaces={18}
                                                                                         value="0.1"
                                                                   />
                                                                    
@@ -2475,6 +2510,7 @@ ShallowWrapper {
                     "props": Object {
                       "main": <SelectableText>
                         <NumericText
+                                                maxDecimalPlaces={18}
                                                 value="0.1"
                         />
                          
@@ -2537,6 +2573,7 @@ ShallowWrapper {
                       main={
                                             <SelectableText>
                                                                   <NumericText
+                                                                                        maxDecimalPlaces={18}
                                                                                         value="0.1"
                                                                   />
                                                                    
@@ -2560,6 +2597,7 @@ ShallowWrapper {
                     "props": Object {
                       "main": <SelectableText>
                         <NumericText
+                                                maxDecimalPlaces={18}
                                                 value="0.1"
                         />
                          
@@ -2930,6 +2968,7 @@ ShallowWrapper {
                                         intl={
                                                   Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                                         }
                                         onChange={[Function]}
@@ -2966,6 +3005,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0"
                                                             />
                                                              
@@ -3000,6 +3040,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.006"
                                                             />
                                                              
@@ -3032,6 +3073,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.198937"
                                                             />
                                                              
@@ -3064,6 +3106,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.192937"
                                                             />
                                                              
@@ -3097,6 +3140,7 @@ ShallowWrapper {
                                                   main={
                                                             <SelectableText>
                                                                       <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.1"
                                                                       />
                                                                        
@@ -3129,6 +3173,7 @@ ShallowWrapper {
                                                   main={
                                                             <SelectableText>
                                                                       <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.1"
                                                                       />
                                                                        
@@ -3288,6 +3333,7 @@ ShallowWrapper {
                                           intl={
                                                         Object {
                                                                       "formatMessage": [Function],
+                                                                      "formatNumber": [Function],
                                                                     }
                                           }
                                           onChange={[Function]}
@@ -3324,6 +3370,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0"
                                                                       />
                                                                        
@@ -3358,6 +3405,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.006"
                                                                       />
                                                                        
@@ -3390,6 +3438,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.198937"
                                                                       />
                                                                        
@@ -3422,6 +3471,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.192937"
                                                                       />
                                                                        
@@ -3455,6 +3505,7 @@ ShallowWrapper {
                                                         main={
                                                                       <SelectableText>
                                                                                     <NumericText
+                                                                                                  maxDecimalPlaces={18}
                                                                                                   value="0.1"
                                                                                     />
                                                                                      
@@ -3487,6 +3538,7 @@ ShallowWrapper {
                                                         main={
                                                                       <SelectableText>
                                                                                     <NumericText
+                                                                                                  maxDecimalPlaces={18}
                                                                                                   value="0.1"
                                                                                     />
                                                                                      
@@ -3643,6 +3695,7 @@ ShallowWrapper {
                                 intl={
                                                 Object {
                                                                 "formatMessage": [Function],
+                                                                "formatNumber": [Function],
                                                               }
                                 }
                                 onChange={[Function]}
@@ -3732,6 +3785,7 @@ ShallowWrapper {
                     intl={
                                         Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                     }
                     onChange={[Function]}
@@ -3904,6 +3958,7 @@ ShallowWrapper {
                     "gasStatistics": undefined,
                     "intl": Object {
                       "formatMessage": [Function],
+                      "formatNumber": [Function],
                     },
                     "onChange": [Function],
                   },
@@ -3969,6 +4024,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0"
                                                                         />
                                                                          
@@ -4003,6 +4059,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.006"
                                                                         />
                                                                          
@@ -4035,6 +4092,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.198937"
                                                                         />
                                                                          
@@ -4067,6 +4125,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.192937"
                                                                         />
                                                                          
@@ -4100,6 +4159,7 @@ ShallowWrapper {
                                                       main={
                                                                         <SelectableText>
                                                                                           <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.1"
                                                                                           />
                                                                                            
@@ -4132,6 +4192,7 @@ ShallowWrapper {
                                                       main={
                                                                         <SelectableText>
                                                                                           <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.1"
                                                                                           />
                                                                                            
@@ -4251,6 +4312,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0"
                                                             />
                                                              
@@ -4274,6 +4336,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0"
                       />
                        
@@ -4345,6 +4408,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.006"
                                                             />
                                                              
@@ -4368,6 +4432,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.006"
                       />
                        
@@ -4430,6 +4495,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.198937"
                                                             />
                                                              
@@ -4453,6 +4519,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.198937"
                       />
                        
@@ -4515,6 +4582,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.192937"
                                                             />
                                                              
@@ -4538,6 +4606,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.192937"
                       />
                        
@@ -4578,6 +4647,7 @@ ShallowWrapper {
                                             main={
                                                                   <SelectableText>
                                                                                         <NumericText
+                                                                                                              maxDecimalPlaces={18}
                                                                                                               value="0.1"
                                                                                         />
                                                                                          
@@ -4610,6 +4680,7 @@ ShallowWrapper {
                                             main={
                                                                   <SelectableText>
                                                                                         <NumericText
+                                                                                                              maxDecimalPlaces={18}
                                                                                                               value="0.1"
                                                                                         />
                                                                                          
@@ -4674,6 +4745,7 @@ ShallowWrapper {
                         main={
                                                 <SelectableText>
                                                                         <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                         />
                                                                          
@@ -4697,6 +4769,7 @@ ShallowWrapper {
                       "props": Object {
                         "main": <SelectableText>
                           <NumericText
+                                                    maxDecimalPlaces={18}
                                                     value="0.1"
                           />
                            
@@ -4759,6 +4832,7 @@ ShallowWrapper {
                         main={
                                                 <SelectableText>
                                                                         <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                         />
                                                                          
@@ -4782,6 +4856,7 @@ ShallowWrapper {
                       "props": Object {
                         "main": <SelectableText>
                           <NumericText
+                                                    maxDecimalPlaces={18}
                                                     value="0.1"
                           />
                            
@@ -5569,6 +5644,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -5781,6 +5857,7 @@ ShallowWrapper {
                                 intl={
                                         Object {
                                                 "formatMessage": [Function],
+                                                "formatNumber": [Function],
                                               }
                                 }
                                 onChange={[Function]}
@@ -5817,6 +5894,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0"
                                                 />
                                                  
@@ -5851,6 +5929,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.006"
                                                 />
                                                  
@@ -5883,6 +5962,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.198937"
                                                 />
                                                  
@@ -5915,6 +5995,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.192937"
                                                 />
                                                  
@@ -5948,6 +6029,7 @@ ShallowWrapper {
                                         main={
                                                 <SelectableText>
                                                         <NumericText
+                                                                maxDecimalPlaces={18}
                                                                 value="0.1"
                                                         />
                                                          
@@ -5980,6 +6062,7 @@ ShallowWrapper {
                                         main={
                                                 <SelectableText>
                                                         <NumericText
+                                                                maxDecimalPlaces={18}
                                                                 value="0.1"
                                                         />
                                                          
@@ -6139,6 +6222,7 @@ ShallowWrapper {
                                     intl={
                                                 Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                                     }
                                     onChange={[Function]}
@@ -6175,6 +6259,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0"
                                                             />
                                                              
@@ -6209,6 +6294,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.006"
                                                             />
                                                              
@@ -6241,6 +6327,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.198937"
                                                             />
                                                              
@@ -6273,6 +6360,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.192937"
                                                             />
                                                              
@@ -6306,6 +6394,7 @@ ShallowWrapper {
                                                 main={
                                                             <SelectableText>
                                                                         <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.1"
                                                                         />
                                                                          
@@ -6338,6 +6427,7 @@ ShallowWrapper {
                                                 main={
                                                             <SelectableText>
                                                                         <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.1"
                                                                         />
                                                                          
@@ -6494,6 +6584,7 @@ ShallowWrapper {
                             intl={
                                           Object {
                                                         "formatMessage": [Function],
+                                                        "formatNumber": [Function],
                                                       }
                             }
                             onChange={[Function]}
@@ -6583,6 +6674,7 @@ ShallowWrapper {
                   intl={
                                     Object {
                                                       "formatMessage": [Function],
+                                                      "formatNumber": [Function],
                                                     }
                   }
                   onChange={[Function]}
@@ -6755,6 +6847,7 @@ ShallowWrapper {
                   "gasStatistics": undefined,
                   "intl": Object {
                     "formatMessage": [Function],
+                    "formatNumber": [Function],
                   },
                   "onChange": [Function],
                 },
@@ -6820,6 +6913,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0"
                                                                 />
                                                                  
@@ -6854,6 +6948,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.006"
                                                                 />
                                                                  
@@ -6886,6 +6981,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.198937"
                                                                 />
                                                                  
@@ -6918,6 +7014,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.192937"
                                                                 />
                                                                  
@@ -6951,6 +7048,7 @@ ShallowWrapper {
                                                 main={
                                                                 <SelectableText>
                                                                                 <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                                 />
                                                                                  
@@ -6983,6 +7081,7 @@ ShallowWrapper {
                                                 main={
                                                                 <SelectableText>
                                                                                 <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                                 />
                                                                                  
@@ -7102,6 +7201,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0"
                                                       />
                                                        
@@ -7125,6 +7225,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0"
                     />
                      
@@ -7196,6 +7297,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.006"
                                                       />
                                                        
@@ -7219,6 +7321,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.006"
                     />
                      
@@ -7281,6 +7384,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.198937"
                                                       />
                                                        
@@ -7304,6 +7408,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.198937"
                     />
                      
@@ -7366,6 +7471,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.192937"
                                                       />
                                                        
@@ -7389,6 +7495,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.192937"
                     />
                      
@@ -7429,6 +7536,7 @@ ShallowWrapper {
                                         main={
                                                             <SelectableText>
                                                                                 <NumericText
+                                                                                                    maxDecimalPlaces={18}
                                                                                                     value="0.1"
                                                                                 />
                                                                                  
@@ -7461,6 +7569,7 @@ ShallowWrapper {
                                         main={
                                                             <SelectableText>
                                                                                 <NumericText
+                                                                                                    maxDecimalPlaces={18}
                                                                                                     value="0.1"
                                                                                 />
                                                                                  
@@ -7525,6 +7634,7 @@ ShallowWrapper {
                       main={
                                             <SelectableText>
                                                                   <NumericText
+                                                                                        maxDecimalPlaces={18}
                                                                                         value="0.1"
                                                                   />
                                                                    
@@ -7548,6 +7658,7 @@ ShallowWrapper {
                     "props": Object {
                       "main": <SelectableText>
                         <NumericText
+                                                maxDecimalPlaces={18}
                                                 value="0.1"
                         />
                          
@@ -7610,6 +7721,7 @@ ShallowWrapper {
                       main={
                                             <SelectableText>
                                                                   <NumericText
+                                                                                        maxDecimalPlaces={18}
                                                                                         value="0.1"
                                                                   />
                                                                    
@@ -7633,6 +7745,7 @@ ShallowWrapper {
                     "props": Object {
                       "main": <SelectableText>
                         <NumericText
+                                                maxDecimalPlaces={18}
                                                 value="0.1"
                         />
                          
@@ -8003,6 +8116,7 @@ ShallowWrapper {
                                         intl={
                                                   Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                                         }
                                         onChange={[Function]}
@@ -8039,6 +8153,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0"
                                                             />
                                                              
@@ -8073,6 +8188,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.006"
                                                             />
                                                              
@@ -8105,6 +8221,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.198937"
                                                             />
                                                              
@@ -8137,6 +8254,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.192937"
                                                             />
                                                              
@@ -8170,6 +8288,7 @@ ShallowWrapper {
                                                   main={
                                                             <SelectableText>
                                                                       <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.1"
                                                                       />
                                                                        
@@ -8202,6 +8321,7 @@ ShallowWrapper {
                                                   main={
                                                             <SelectableText>
                                                                       <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.1"
                                                                       />
                                                                        
@@ -8361,6 +8481,7 @@ ShallowWrapper {
                                           intl={
                                                         Object {
                                                                       "formatMessage": [Function],
+                                                                      "formatNumber": [Function],
                                                                     }
                                           }
                                           onChange={[Function]}
@@ -8397,6 +8518,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0"
                                                                       />
                                                                        
@@ -8431,6 +8553,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.006"
                                                                       />
                                                                        
@@ -8463,6 +8586,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.198937"
                                                                       />
                                                                        
@@ -8495,6 +8619,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.192937"
                                                                       />
                                                                        
@@ -8528,6 +8653,7 @@ ShallowWrapper {
                                                         main={
                                                                       <SelectableText>
                                                                                     <NumericText
+                                                                                                  maxDecimalPlaces={18}
                                                                                                   value="0.1"
                                                                                     />
                                                                                      
@@ -8560,6 +8686,7 @@ ShallowWrapper {
                                                         main={
                                                                       <SelectableText>
                                                                                     <NumericText
+                                                                                                  maxDecimalPlaces={18}
                                                                                                   value="0.1"
                                                                                     />
                                                                                      
@@ -8716,6 +8843,7 @@ ShallowWrapper {
                                 intl={
                                                 Object {
                                                                 "formatMessage": [Function],
+                                                                "formatNumber": [Function],
                                                               }
                                 }
                                 onChange={[Function]}
@@ -8805,6 +8933,7 @@ ShallowWrapper {
                     intl={
                                         Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                     }
                     onChange={[Function]}
@@ -8977,6 +9106,7 @@ ShallowWrapper {
                     "gasStatistics": undefined,
                     "intl": Object {
                       "formatMessage": [Function],
+                      "formatNumber": [Function],
                     },
                     "onChange": [Function],
                   },
@@ -9042,6 +9172,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0"
                                                                         />
                                                                          
@@ -9076,6 +9207,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.006"
                                                                         />
                                                                          
@@ -9108,6 +9240,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.198937"
                                                                         />
                                                                          
@@ -9140,6 +9273,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.192937"
                                                                         />
                                                                          
@@ -9173,6 +9307,7 @@ ShallowWrapper {
                                                       main={
                                                                         <SelectableText>
                                                                                           <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.1"
                                                                                           />
                                                                                            
@@ -9205,6 +9340,7 @@ ShallowWrapper {
                                                       main={
                                                                         <SelectableText>
                                                                                           <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.1"
                                                                                           />
                                                                                            
@@ -9324,6 +9460,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0"
                                                             />
                                                              
@@ -9347,6 +9484,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0"
                       />
                        
@@ -9418,6 +9556,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.006"
                                                             />
                                                              
@@ -9441,6 +9580,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.006"
                       />
                        
@@ -9503,6 +9643,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.198937"
                                                             />
                                                              
@@ -9526,6 +9667,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.198937"
                       />
                        
@@ -9588,6 +9730,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.192937"
                                                             />
                                                              
@@ -9611,6 +9754,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.192937"
                       />
                        
@@ -9651,6 +9795,7 @@ ShallowWrapper {
                                             main={
                                                                   <SelectableText>
                                                                                         <NumericText
+                                                                                                              maxDecimalPlaces={18}
                                                                                                               value="0.1"
                                                                                         />
                                                                                          
@@ -9683,6 +9828,7 @@ ShallowWrapper {
                                             main={
                                                                   <SelectableText>
                                                                                         <NumericText
+                                                                                                              maxDecimalPlaces={18}
                                                                                                               value="0.1"
                                                                                         />
                                                                                          
@@ -9747,6 +9893,7 @@ ShallowWrapper {
                         main={
                                                 <SelectableText>
                                                                         <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                         />
                                                                          
@@ -9770,6 +9917,7 @@ ShallowWrapper {
                       "props": Object {
                         "main": <SelectableText>
                           <NumericText
+                                                    maxDecimalPlaces={18}
                                                     value="0.1"
                           />
                            
@@ -9832,6 +9980,7 @@ ShallowWrapper {
                         main={
                                                 <SelectableText>
                                                                         <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                         />
                                                                          
@@ -9855,6 +10004,7 @@ ShallowWrapper {
                       "props": Object {
                         "main": <SelectableText>
                           <NumericText
+                                                    maxDecimalPlaces={18}
                                                     value="0.1"
                           />
                            
@@ -10642,6 +10792,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -10854,6 +11005,7 @@ ShallowWrapper {
                                 intl={
                                         Object {
                                                 "formatMessage": [Function],
+                                                "formatNumber": [Function],
                                               }
                                 }
                                 onChange={[Function]}
@@ -10890,6 +11042,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0"
                                                 />
                                                  
@@ -10924,6 +11077,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.006"
                                                 />
                                                  
@@ -10956,6 +11110,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.198937"
                                                 />
                                                  
@@ -10988,6 +11143,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.192937"
                                                 />
                                                  
@@ -11021,6 +11177,7 @@ ShallowWrapper {
                                         main={
                                                 <SelectableText>
                                                         <NumericText
+                                                                maxDecimalPlaces={18}
                                                                 value="0.1"
                                                         />
                                                          
@@ -11053,6 +11210,7 @@ ShallowWrapper {
                                         main={
                                                 <SelectableText>
                                                         <NumericText
+                                                                maxDecimalPlaces={18}
                                                                 value="0.1"
                                                         />
                                                          
@@ -11212,6 +11370,7 @@ ShallowWrapper {
                                     intl={
                                                 Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                                     }
                                     onChange={[Function]}
@@ -11248,6 +11407,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0"
                                                             />
                                                              
@@ -11282,6 +11442,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.006"
                                                             />
                                                              
@@ -11314,6 +11475,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.198937"
                                                             />
                                                              
@@ -11346,6 +11508,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.192937"
                                                             />
                                                              
@@ -11379,6 +11542,7 @@ ShallowWrapper {
                                                 main={
                                                             <SelectableText>
                                                                         <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.1"
                                                                         />
                                                                          
@@ -11411,6 +11575,7 @@ ShallowWrapper {
                                                 main={
                                                             <SelectableText>
                                                                         <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.1"
                                                                         />
                                                                          
@@ -11567,6 +11732,7 @@ ShallowWrapper {
                             intl={
                                           Object {
                                                         "formatMessage": [Function],
+                                                        "formatNumber": [Function],
                                                       }
                             }
                             onChange={[Function]}
@@ -11656,6 +11822,7 @@ ShallowWrapper {
                   intl={
                                     Object {
                                                       "formatMessage": [Function],
+                                                      "formatNumber": [Function],
                                                     }
                   }
                   onChange={[Function]}
@@ -11828,6 +11995,7 @@ ShallowWrapper {
                   "gasStatistics": undefined,
                   "intl": Object {
                     "formatMessage": [Function],
+                    "formatNumber": [Function],
                   },
                   "onChange": [Function],
                 },
@@ -11893,6 +12061,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0"
                                                                 />
                                                                  
@@ -11927,6 +12096,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.006"
                                                                 />
                                                                  
@@ -11959,6 +12129,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.198937"
                                                                 />
                                                                  
@@ -11991,6 +12162,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.192937"
                                                                 />
                                                                  
@@ -12024,6 +12196,7 @@ ShallowWrapper {
                                                 main={
                                                                 <SelectableText>
                                                                                 <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                                 />
                                                                                  
@@ -12056,6 +12229,7 @@ ShallowWrapper {
                                                 main={
                                                                 <SelectableText>
                                                                                 <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                                 />
                                                                                  
@@ -12175,6 +12349,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0"
                                                       />
                                                        
@@ -12198,6 +12373,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0"
                     />
                      
@@ -12269,6 +12445,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.006"
                                                       />
                                                        
@@ -12292,6 +12469,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.006"
                     />
                      
@@ -12354,6 +12532,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.198937"
                                                       />
                                                        
@@ -12377,6 +12556,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.198937"
                     />
                      
@@ -12439,6 +12619,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.192937"
                                                       />
                                                        
@@ -12462,6 +12643,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.192937"
                     />
                      
@@ -12502,6 +12684,7 @@ ShallowWrapper {
                                         main={
                                                             <SelectableText>
                                                                                 <NumericText
+                                                                                                    maxDecimalPlaces={18}
                                                                                                     value="0.1"
                                                                                 />
                                                                                  
@@ -12534,6 +12717,7 @@ ShallowWrapper {
                                         main={
                                                             <SelectableText>
                                                                                 <NumericText
+                                                                                                    maxDecimalPlaces={18}
                                                                                                     value="0.1"
                                                                                 />
                                                                                  
@@ -12598,6 +12782,7 @@ ShallowWrapper {
                       main={
                                             <SelectableText>
                                                                   <NumericText
+                                                                                        maxDecimalPlaces={18}
                                                                                         value="0.1"
                                                                   />
                                                                    
@@ -12621,6 +12806,7 @@ ShallowWrapper {
                     "props": Object {
                       "main": <SelectableText>
                         <NumericText
+                                                maxDecimalPlaces={18}
                                                 value="0.1"
                         />
                          
@@ -12683,6 +12869,7 @@ ShallowWrapper {
                       main={
                                             <SelectableText>
                                                                   <NumericText
+                                                                                        maxDecimalPlaces={18}
                                                                                         value="0.1"
                                                                   />
                                                                    
@@ -12706,6 +12893,7 @@ ShallowWrapper {
                     "props": Object {
                       "main": <SelectableText>
                         <NumericText
+                                                maxDecimalPlaces={18}
                                                 value="0.1"
                         />
                          
@@ -13076,6 +13264,7 @@ ShallowWrapper {
                                         intl={
                                                   Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                                         }
                                         onChange={[Function]}
@@ -13112,6 +13301,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0"
                                                             />
                                                              
@@ -13146,6 +13336,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.006"
                                                             />
                                                              
@@ -13178,6 +13369,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.198937"
                                                             />
                                                              
@@ -13210,6 +13402,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.192937"
                                                             />
                                                              
@@ -13243,6 +13436,7 @@ ShallowWrapper {
                                                   main={
                                                             <SelectableText>
                                                                       <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.1"
                                                                       />
                                                                        
@@ -13275,6 +13469,7 @@ ShallowWrapper {
                                                   main={
                                                             <SelectableText>
                                                                       <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.1"
                                                                       />
                                                                        
@@ -13434,6 +13629,7 @@ ShallowWrapper {
                                           intl={
                                                         Object {
                                                                       "formatMessage": [Function],
+                                                                      "formatNumber": [Function],
                                                                     }
                                           }
                                           onChange={[Function]}
@@ -13470,6 +13666,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0"
                                                                       />
                                                                        
@@ -13504,6 +13701,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.006"
                                                                       />
                                                                        
@@ -13536,6 +13734,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.198937"
                                                                       />
                                                                        
@@ -13568,6 +13767,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.192937"
                                                                       />
                                                                        
@@ -13601,6 +13801,7 @@ ShallowWrapper {
                                                         main={
                                                                       <SelectableText>
                                                                                     <NumericText
+                                                                                                  maxDecimalPlaces={18}
                                                                                                   value="0.1"
                                                                                     />
                                                                                      
@@ -13633,6 +13834,7 @@ ShallowWrapper {
                                                         main={
                                                                       <SelectableText>
                                                                                     <NumericText
+                                                                                                  maxDecimalPlaces={18}
                                                                                                   value="0.1"
                                                                                     />
                                                                                      
@@ -13789,6 +13991,7 @@ ShallowWrapper {
                                 intl={
                                                 Object {
                                                                 "formatMessage": [Function],
+                                                                "formatNumber": [Function],
                                                               }
                                 }
                                 onChange={[Function]}
@@ -13878,6 +14081,7 @@ ShallowWrapper {
                     intl={
                                         Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                     }
                     onChange={[Function]}
@@ -14050,6 +14254,7 @@ ShallowWrapper {
                     "gasStatistics": undefined,
                     "intl": Object {
                       "formatMessage": [Function],
+                      "formatNumber": [Function],
                     },
                     "onChange": [Function],
                   },
@@ -14115,6 +14320,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0"
                                                                         />
                                                                          
@@ -14149,6 +14355,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.006"
                                                                         />
                                                                          
@@ -14181,6 +14388,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.198937"
                                                                         />
                                                                          
@@ -14213,6 +14421,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.192937"
                                                                         />
                                                                          
@@ -14246,6 +14455,7 @@ ShallowWrapper {
                                                       main={
                                                                         <SelectableText>
                                                                                           <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.1"
                                                                                           />
                                                                                            
@@ -14278,6 +14488,7 @@ ShallowWrapper {
                                                       main={
                                                                         <SelectableText>
                                                                                           <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.1"
                                                                                           />
                                                                                            
@@ -14397,6 +14608,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0"
                                                             />
                                                              
@@ -14420,6 +14632,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0"
                       />
                        
@@ -14491,6 +14704,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.006"
                                                             />
                                                              
@@ -14514,6 +14728,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.006"
                       />
                        
@@ -14576,6 +14791,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.198937"
                                                             />
                                                              
@@ -14599,6 +14815,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.198937"
                       />
                        
@@ -14661,6 +14878,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.192937"
                                                             />
                                                              
@@ -14684,6 +14902,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.192937"
                       />
                        
@@ -14724,6 +14943,7 @@ ShallowWrapper {
                                             main={
                                                                   <SelectableText>
                                                                                         <NumericText
+                                                                                                              maxDecimalPlaces={18}
                                                                                                               value="0.1"
                                                                                         />
                                                                                          
@@ -14756,6 +14976,7 @@ ShallowWrapper {
                                             main={
                                                                   <SelectableText>
                                                                                         <NumericText
+                                                                                                              maxDecimalPlaces={18}
                                                                                                               value="0.1"
                                                                                         />
                                                                                          
@@ -14820,6 +15041,7 @@ ShallowWrapper {
                         main={
                                                 <SelectableText>
                                                                         <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                         />
                                                                          
@@ -14843,6 +15065,7 @@ ShallowWrapper {
                       "props": Object {
                         "main": <SelectableText>
                           <NumericText
+                                                    maxDecimalPlaces={18}
                                                     value="0.1"
                           />
                            
@@ -14905,6 +15128,7 @@ ShallowWrapper {
                         main={
                                                 <SelectableText>
                                                                         <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                         />
                                                                          
@@ -14928,6 +15152,7 @@ ShallowWrapper {
                       "props": Object {
                         "main": <SelectableText>
                           <NumericText
+                                                    maxDecimalPlaces={18}
                                                     value="0.1"
                           />
                            
@@ -15715,6 +15940,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -15927,6 +16153,7 @@ ShallowWrapper {
                                 intl={
                                         Object {
                                                 "formatMessage": [Function],
+                                                "formatNumber": [Function],
                                               }
                                 }
                                 onChange={[Function]}
@@ -15963,6 +16190,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0"
                                                 />
                                                  
@@ -15997,6 +16225,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.006"
                                                 />
                                                  
@@ -16029,6 +16258,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.198937"
                                                 />
                                                  
@@ -16061,6 +16291,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.192937"
                                                 />
                                                  
@@ -16094,6 +16325,7 @@ ShallowWrapper {
                                         main={
                                                 <SelectableText>
                                                         <NumericText
+                                                                maxDecimalPlaces={18}
                                                                 value="0.1"
                                                         />
                                                          
@@ -16126,6 +16358,7 @@ ShallowWrapper {
                                         main={
                                                 <SelectableText>
                                                         <NumericText
+                                                                maxDecimalPlaces={18}
                                                                 value="0.1"
                                                         />
                                                          
@@ -16259,6 +16492,7 @@ ShallowWrapper {
                                     intl={
                                                 Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                                     }
                                     onChange={[Function]}
@@ -16295,6 +16529,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0"
                                                             />
                                                              
@@ -16329,6 +16564,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.006"
                                                             />
                                                              
@@ -16361,6 +16597,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.198937"
                                                             />
                                                              
@@ -16393,6 +16630,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.192937"
                                                             />
                                                              
@@ -16426,6 +16664,7 @@ ShallowWrapper {
                                                 main={
                                                             <SelectableText>
                                                                         <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.1"
                                                                         />
                                                                          
@@ -16458,6 +16697,7 @@ ShallowWrapper {
                                                 main={
                                                             <SelectableText>
                                                                         <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.1"
                                                                         />
                                                                          
@@ -16588,6 +16828,7 @@ ShallowWrapper {
                             intl={
                                           Object {
                                                         "formatMessage": [Function],
+                                                        "formatNumber": [Function],
                                                       }
                             }
                             onChange={[Function]}
@@ -16677,6 +16918,7 @@ ShallowWrapper {
                   intl={
                                     Object {
                                                       "formatMessage": [Function],
+                                                      "formatNumber": [Function],
                                                     }
                   }
                   onChange={[Function]}
@@ -16849,6 +17091,7 @@ ShallowWrapper {
                   "gasStatistics": undefined,
                   "intl": Object {
                     "formatMessage": [Function],
+                    "formatNumber": [Function],
                   },
                   "onChange": [Function],
                 },
@@ -16914,6 +17157,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0"
                                                                 />
                                                                  
@@ -16948,6 +17192,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.006"
                                                                 />
                                                                  
@@ -16980,6 +17225,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.198937"
                                                                 />
                                                                  
@@ -17012,6 +17258,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.192937"
                                                                 />
                                                                  
@@ -17045,6 +17292,7 @@ ShallowWrapper {
                                                 main={
                                                                 <SelectableText>
                                                                                 <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                                 />
                                                                                  
@@ -17077,6 +17325,7 @@ ShallowWrapper {
                                                 main={
                                                                 <SelectableText>
                                                                                 <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                                 />
                                                                                  
@@ -17170,6 +17419,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0"
                                                       />
                                                        
@@ -17193,6 +17443,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0"
                     />
                      
@@ -17264,6 +17515,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.006"
                                                       />
                                                        
@@ -17287,6 +17539,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.006"
                     />
                      
@@ -17349,6 +17602,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.198937"
                                                       />
                                                        
@@ -17372,6 +17626,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.198937"
                     />
                      
@@ -17434,6 +17689,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.192937"
                                                       />
                                                        
@@ -17457,6 +17713,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.192937"
                     />
                      
@@ -17497,6 +17754,7 @@ ShallowWrapper {
                                         main={
                                                             <SelectableText>
                                                                                 <NumericText
+                                                                                                    maxDecimalPlaces={18}
                                                                                                     value="0.1"
                                                                                 />
                                                                                  
@@ -17529,6 +17787,7 @@ ShallowWrapper {
                                         main={
                                                             <SelectableText>
                                                                                 <NumericText
+                                                                                                    maxDecimalPlaces={18}
                                                                                                     value="0.1"
                                                                                 />
                                                                                  
@@ -17593,6 +17852,7 @@ ShallowWrapper {
                       main={
                                             <SelectableText>
                                                                   <NumericText
+                                                                                        maxDecimalPlaces={18}
                                                                                         value="0.1"
                                                                   />
                                                                    
@@ -17616,6 +17876,7 @@ ShallowWrapper {
                     "props": Object {
                       "main": <SelectableText>
                         <NumericText
+                                                maxDecimalPlaces={18}
                                                 value="0.1"
                         />
                          
@@ -17678,6 +17939,7 @@ ShallowWrapper {
                       main={
                                             <SelectableText>
                                                                   <NumericText
+                                                                                        maxDecimalPlaces={18}
                                                                                         value="0.1"
                                                                   />
                                                                    
@@ -17701,6 +17963,7 @@ ShallowWrapper {
                     "props": Object {
                       "main": <SelectableText>
                         <NumericText
+                                                maxDecimalPlaces={18}
                                                 value="0.1"
                         />
                          
@@ -17934,6 +18197,7 @@ ShallowWrapper {
                                         intl={
                                                   Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                                         }
                                         onChange={[Function]}
@@ -17970,6 +18234,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0"
                                                             />
                                                              
@@ -18004,6 +18269,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.006"
                                                             />
                                                              
@@ -18036,6 +18302,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.198937"
                                                             />
                                                              
@@ -18068,6 +18335,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.192937"
                                                             />
                                                              
@@ -18101,6 +18369,7 @@ ShallowWrapper {
                                                   main={
                                                             <SelectableText>
                                                                       <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.1"
                                                                       />
                                                                        
@@ -18133,6 +18402,7 @@ ShallowWrapper {
                                                   main={
                                                             <SelectableText>
                                                                       <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.1"
                                                                       />
                                                                        
@@ -18266,6 +18536,7 @@ ShallowWrapper {
                                           intl={
                                                         Object {
                                                                       "formatMessage": [Function],
+                                                                      "formatNumber": [Function],
                                                                     }
                                           }
                                           onChange={[Function]}
@@ -18302,6 +18573,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0"
                                                                       />
                                                                        
@@ -18336,6 +18608,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.006"
                                                                       />
                                                                        
@@ -18368,6 +18641,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.198937"
                                                                       />
                                                                        
@@ -18400,6 +18674,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.192937"
                                                                       />
                                                                        
@@ -18433,6 +18708,7 @@ ShallowWrapper {
                                                         main={
                                                                       <SelectableText>
                                                                                     <NumericText
+                                                                                                  maxDecimalPlaces={18}
                                                                                                   value="0.1"
                                                                                     />
                                                                                      
@@ -18465,6 +18741,7 @@ ShallowWrapper {
                                                         main={
                                                                       <SelectableText>
                                                                                     <NumericText
+                                                                                                  maxDecimalPlaces={18}
                                                                                                   value="0.1"
                                                                                     />
                                                                                      
@@ -18595,6 +18872,7 @@ ShallowWrapper {
                                 intl={
                                                 Object {
                                                                 "formatMessage": [Function],
+                                                                "formatNumber": [Function],
                                                               }
                                 }
                                 onChange={[Function]}
@@ -18684,6 +18962,7 @@ ShallowWrapper {
                     intl={
                                         Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                     }
                     onChange={[Function]}
@@ -18856,6 +19135,7 @@ ShallowWrapper {
                     "gasStatistics": undefined,
                     "intl": Object {
                       "formatMessage": [Function],
+                      "formatNumber": [Function],
                     },
                     "onChange": [Function],
                   },
@@ -18921,6 +19201,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0"
                                                                         />
                                                                          
@@ -18955,6 +19236,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.006"
                                                                         />
                                                                          
@@ -18987,6 +19269,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.198937"
                                                                         />
                                                                          
@@ -19019,6 +19302,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.192937"
                                                                         />
                                                                          
@@ -19052,6 +19336,7 @@ ShallowWrapper {
                                                       main={
                                                                         <SelectableText>
                                                                                           <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.1"
                                                                                           />
                                                                                            
@@ -19084,6 +19369,7 @@ ShallowWrapper {
                                                       main={
                                                                         <SelectableText>
                                                                                           <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.1"
                                                                                           />
                                                                                            
@@ -19177,6 +19463,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0"
                                                             />
                                                              
@@ -19200,6 +19487,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0"
                       />
                        
@@ -19271,6 +19559,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.006"
                                                             />
                                                              
@@ -19294,6 +19583,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.006"
                       />
                        
@@ -19356,6 +19646,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.198937"
                                                             />
                                                              
@@ -19379,6 +19670,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.198937"
                       />
                        
@@ -19441,6 +19733,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.192937"
                                                             />
                                                              
@@ -19464,6 +19757,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.192937"
                       />
                        
@@ -19504,6 +19798,7 @@ ShallowWrapper {
                                             main={
                                                                   <SelectableText>
                                                                                         <NumericText
+                                                                                                              maxDecimalPlaces={18}
                                                                                                               value="0.1"
                                                                                         />
                                                                                          
@@ -19536,6 +19831,7 @@ ShallowWrapper {
                                             main={
                                                                   <SelectableText>
                                                                                         <NumericText
+                                                                                                              maxDecimalPlaces={18}
                                                                                                               value="0.1"
                                                                                         />
                                                                                          
@@ -19600,6 +19896,7 @@ ShallowWrapper {
                         main={
                                                 <SelectableText>
                                                                         <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                         />
                                                                          
@@ -19623,6 +19920,7 @@ ShallowWrapper {
                       "props": Object {
                         "main": <SelectableText>
                           <NumericText
+                                                    maxDecimalPlaces={18}
                                                     value="0.1"
                           />
                            
@@ -19685,6 +19983,7 @@ ShallowWrapper {
                         main={
                                                 <SelectableText>
                                                                         <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                         />
                                                                          
@@ -19708,6 +20007,7 @@ ShallowWrapper {
                       "props": Object {
                         "main": <SelectableText>
                           <NumericText
+                                                    maxDecimalPlaces={18}
                                                     value="0.1"
                           />
                            
@@ -20358,6 +20658,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -20570,6 +20871,7 @@ ShallowWrapper {
                                 intl={
                                         Object {
                                                 "formatMessage": [Function],
+                                                "formatNumber": [Function],
                                               }
                                 }
                                 onChange={[Function]}
@@ -20606,6 +20908,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0"
                                                 />
                                                  
@@ -20640,6 +20943,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.006"
                                                 />
                                                  
@@ -20672,6 +20976,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.198937"
                                                 />
                                                  
@@ -20704,6 +21009,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.192937"
                                                 />
                                                  
@@ -20737,6 +21043,7 @@ ShallowWrapper {
                                         main={
                                                 <SelectableText>
                                                         <NumericText
+                                                                maxDecimalPlaces={18}
                                                                 value="0.1"
                                                         />
                                                          
@@ -20769,6 +21076,7 @@ ShallowWrapper {
                                         main={
                                                 <SelectableText>
                                                         <NumericText
+                                                                maxDecimalPlaces={18}
                                                                 value="0.1"
                                                         />
                                                          
@@ -20902,6 +21210,7 @@ ShallowWrapper {
                                     intl={
                                                 Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                                     }
                                     onChange={[Function]}
@@ -20938,6 +21247,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0"
                                                             />
                                                              
@@ -20972,6 +21282,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.006"
                                                             />
                                                              
@@ -21004,6 +21315,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.198937"
                                                             />
                                                              
@@ -21036,6 +21348,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.192937"
                                                             />
                                                              
@@ -21069,6 +21382,7 @@ ShallowWrapper {
                                                 main={
                                                             <SelectableText>
                                                                         <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.1"
                                                                         />
                                                                          
@@ -21101,6 +21415,7 @@ ShallowWrapper {
                                                 main={
                                                             <SelectableText>
                                                                         <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.1"
                                                                         />
                                                                          
@@ -21231,6 +21546,7 @@ ShallowWrapper {
                             intl={
                                           Object {
                                                         "formatMessage": [Function],
+                                                        "formatNumber": [Function],
                                                       }
                             }
                             onChange={[Function]}
@@ -21320,6 +21636,7 @@ ShallowWrapper {
                   intl={
                                     Object {
                                                       "formatMessage": [Function],
+                                                      "formatNumber": [Function],
                                                     }
                   }
                   onChange={[Function]}
@@ -21492,6 +21809,7 @@ ShallowWrapper {
                   "gasStatistics": undefined,
                   "intl": Object {
                     "formatMessage": [Function],
+                    "formatNumber": [Function],
                   },
                   "onChange": [Function],
                 },
@@ -21557,6 +21875,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0"
                                                                 />
                                                                  
@@ -21591,6 +21910,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.006"
                                                                 />
                                                                  
@@ -21623,6 +21943,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.198937"
                                                                 />
                                                                  
@@ -21655,6 +21976,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.192937"
                                                                 />
                                                                  
@@ -21688,6 +22010,7 @@ ShallowWrapper {
                                                 main={
                                                                 <SelectableText>
                                                                                 <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                                 />
                                                                                  
@@ -21720,6 +22043,7 @@ ShallowWrapper {
                                                 main={
                                                                 <SelectableText>
                                                                                 <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                                 />
                                                                                  
@@ -21813,6 +22137,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0"
                                                       />
                                                        
@@ -21836,6 +22161,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0"
                     />
                      
@@ -21907,6 +22233,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.006"
                                                       />
                                                        
@@ -21930,6 +22257,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.006"
                     />
                      
@@ -21992,6 +22320,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.198937"
                                                       />
                                                        
@@ -22015,6 +22344,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.198937"
                     />
                      
@@ -22077,6 +22407,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.192937"
                                                       />
                                                        
@@ -22100,6 +22431,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.192937"
                     />
                      
@@ -22140,6 +22472,7 @@ ShallowWrapper {
                                         main={
                                                             <SelectableText>
                                                                                 <NumericText
+                                                                                                    maxDecimalPlaces={18}
                                                                                                     value="0.1"
                                                                                 />
                                                                                  
@@ -22172,6 +22505,7 @@ ShallowWrapper {
                                         main={
                                                             <SelectableText>
                                                                                 <NumericText
+                                                                                                    maxDecimalPlaces={18}
                                                                                                     value="0.1"
                                                                                 />
                                                                                  
@@ -22236,6 +22570,7 @@ ShallowWrapper {
                       main={
                                             <SelectableText>
                                                                   <NumericText
+                                                                                        maxDecimalPlaces={18}
                                                                                         value="0.1"
                                                                   />
                                                                    
@@ -22259,6 +22594,7 @@ ShallowWrapper {
                     "props": Object {
                       "main": <SelectableText>
                         <NumericText
+                                                maxDecimalPlaces={18}
                                                 value="0.1"
                         />
                          
@@ -22321,6 +22657,7 @@ ShallowWrapper {
                       main={
                                             <SelectableText>
                                                                   <NumericText
+                                                                                        maxDecimalPlaces={18}
                                                                                         value="0.1"
                                                                   />
                                                                    
@@ -22344,6 +22681,7 @@ ShallowWrapper {
                     "props": Object {
                       "main": <SelectableText>
                         <NumericText
+                                                maxDecimalPlaces={18}
                                                 value="0.1"
                         />
                          
@@ -22577,6 +22915,7 @@ ShallowWrapper {
                                         intl={
                                                   Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                                         }
                                         onChange={[Function]}
@@ -22613,6 +22952,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0"
                                                             />
                                                              
@@ -22647,6 +22987,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.006"
                                                             />
                                                              
@@ -22679,6 +23020,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.198937"
                                                             />
                                                              
@@ -22711,6 +23053,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.192937"
                                                             />
                                                              
@@ -22744,6 +23087,7 @@ ShallowWrapper {
                                                   main={
                                                             <SelectableText>
                                                                       <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.1"
                                                                       />
                                                                        
@@ -22776,6 +23120,7 @@ ShallowWrapper {
                                                   main={
                                                             <SelectableText>
                                                                       <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.1"
                                                                       />
                                                                        
@@ -22909,6 +23254,7 @@ ShallowWrapper {
                                           intl={
                                                         Object {
                                                                       "formatMessage": [Function],
+                                                                      "formatNumber": [Function],
                                                                     }
                                           }
                                           onChange={[Function]}
@@ -22945,6 +23291,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0"
                                                                       />
                                                                        
@@ -22979,6 +23326,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.006"
                                                                       />
                                                                        
@@ -23011,6 +23359,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.198937"
                                                                       />
                                                                        
@@ -23043,6 +23392,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.192937"
                                                                       />
                                                                        
@@ -23076,6 +23426,7 @@ ShallowWrapper {
                                                         main={
                                                                       <SelectableText>
                                                                                     <NumericText
+                                                                                                  maxDecimalPlaces={18}
                                                                                                   value="0.1"
                                                                                     />
                                                                                      
@@ -23108,6 +23459,7 @@ ShallowWrapper {
                                                         main={
                                                                       <SelectableText>
                                                                                     <NumericText
+                                                                                                  maxDecimalPlaces={18}
                                                                                                   value="0.1"
                                                                                     />
                                                                                      
@@ -23238,6 +23590,7 @@ ShallowWrapper {
                                 intl={
                                                 Object {
                                                                 "formatMessage": [Function],
+                                                                "formatNumber": [Function],
                                                               }
                                 }
                                 onChange={[Function]}
@@ -23327,6 +23680,7 @@ ShallowWrapper {
                     intl={
                                         Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                     }
                     onChange={[Function]}
@@ -23499,6 +23853,7 @@ ShallowWrapper {
                     "gasStatistics": undefined,
                     "intl": Object {
                       "formatMessage": [Function],
+                      "formatNumber": [Function],
                     },
                     "onChange": [Function],
                   },
@@ -23564,6 +23919,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0"
                                                                         />
                                                                          
@@ -23598,6 +23954,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.006"
                                                                         />
                                                                          
@@ -23630,6 +23987,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.198937"
                                                                         />
                                                                          
@@ -23662,6 +24020,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.192937"
                                                                         />
                                                                          
@@ -23695,6 +24054,7 @@ ShallowWrapper {
                                                       main={
                                                                         <SelectableText>
                                                                                           <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.1"
                                                                                           />
                                                                                            
@@ -23727,6 +24087,7 @@ ShallowWrapper {
                                                       main={
                                                                         <SelectableText>
                                                                                           <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.1"
                                                                                           />
                                                                                            
@@ -23820,6 +24181,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0"
                                                             />
                                                              
@@ -23843,6 +24205,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0"
                       />
                        
@@ -23914,6 +24277,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.006"
                                                             />
                                                              
@@ -23937,6 +24301,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.006"
                       />
                        
@@ -23999,6 +24364,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.198937"
                                                             />
                                                              
@@ -24022,6 +24388,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.198937"
                       />
                        
@@ -24084,6 +24451,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.192937"
                                                             />
                                                              
@@ -24107,6 +24475,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.192937"
                       />
                        
@@ -24147,6 +24516,7 @@ ShallowWrapper {
                                             main={
                                                                   <SelectableText>
                                                                                         <NumericText
+                                                                                                              maxDecimalPlaces={18}
                                                                                                               value="0.1"
                                                                                         />
                                                                                          
@@ -24179,6 +24549,7 @@ ShallowWrapper {
                                             main={
                                                                   <SelectableText>
                                                                                         <NumericText
+                                                                                                              maxDecimalPlaces={18}
                                                                                                               value="0.1"
                                                                                         />
                                                                                          
@@ -24243,6 +24614,7 @@ ShallowWrapper {
                         main={
                                                 <SelectableText>
                                                                         <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                         />
                                                                          
@@ -24266,6 +24638,7 @@ ShallowWrapper {
                       "props": Object {
                         "main": <SelectableText>
                           <NumericText
+                                                    maxDecimalPlaces={18}
                                                     value="0.1"
                           />
                            
@@ -24328,6 +24701,7 @@ ShallowWrapper {
                         main={
                                                 <SelectableText>
                                                                         <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                         />
                                                                          
@@ -24351,6 +24725,7 @@ ShallowWrapper {
                       "props": Object {
                         "main": <SelectableText>
                           <NumericText
+                                                    maxDecimalPlaces={18}
                                                     value="0.1"
                           />
                            
@@ -25001,6 +25376,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -25214,6 +25590,7 @@ ShallowWrapper {
                                 intl={
                                         Object {
                                                 "formatMessage": [Function],
+                                                "formatNumber": [Function],
                                               }
                                 }
                                 onChange={[Function]}
@@ -25250,6 +25627,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0"
                                                 />
                                                  
@@ -25284,6 +25662,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.006"
                                                 />
                                                  
@@ -25316,6 +25695,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.198937"
                                                 />
                                                  
@@ -25348,6 +25728,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.192937"
                                                 />
                                                  
@@ -25381,6 +25762,7 @@ ShallowWrapper {
                                         main={
                                                 <SelectableText>
                                                         <NumericText
+                                                                maxDecimalPlaces={18}
                                                                 value="0.1"
                                                         />
                                                          
@@ -25413,6 +25795,7 @@ ShallowWrapper {
                                         main={
                                                 <SelectableText>
                                                         <NumericText
+                                                                maxDecimalPlaces={18}
                                                                 value="0.1"
                                                         />
                                                          
@@ -25546,6 +25929,7 @@ ShallowWrapper {
                                     intl={
                                                 Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                                     }
                                     onChange={[Function]}
@@ -25582,6 +25966,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0"
                                                             />
                                                              
@@ -25616,6 +26001,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.006"
                                                             />
                                                              
@@ -25648,6 +26034,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.198937"
                                                             />
                                                              
@@ -25680,6 +26067,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.192937"
                                                             />
                                                              
@@ -25713,6 +26101,7 @@ ShallowWrapper {
                                                 main={
                                                             <SelectableText>
                                                                         <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.1"
                                                                         />
                                                                          
@@ -25745,6 +26134,7 @@ ShallowWrapper {
                                                 main={
                                                             <SelectableText>
                                                                         <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.1"
                                                                         />
                                                                          
@@ -25875,6 +26265,7 @@ ShallowWrapper {
                             intl={
                                           Object {
                                                         "formatMessage": [Function],
+                                                        "formatNumber": [Function],
                                                       }
                             }
                             onChange={[Function]}
@@ -25964,6 +26355,7 @@ ShallowWrapper {
                   intl={
                                     Object {
                                                       "formatMessage": [Function],
+                                                      "formatNumber": [Function],
                                                     }
                   }
                   onChange={[Function]}
@@ -26136,6 +26528,7 @@ ShallowWrapper {
                   "gasStatistics": undefined,
                   "intl": Object {
                     "formatMessage": [Function],
+                    "formatNumber": [Function],
                   },
                   "onChange": [Function],
                 },
@@ -26201,6 +26594,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0"
                                                                 />
                                                                  
@@ -26235,6 +26629,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.006"
                                                                 />
                                                                  
@@ -26267,6 +26662,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.198937"
                                                                 />
                                                                  
@@ -26299,6 +26695,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.192937"
                                                                 />
                                                                  
@@ -26332,6 +26729,7 @@ ShallowWrapper {
                                                 main={
                                                                 <SelectableText>
                                                                                 <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                                 />
                                                                                  
@@ -26364,6 +26762,7 @@ ShallowWrapper {
                                                 main={
                                                                 <SelectableText>
                                                                                 <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                                 />
                                                                                  
@@ -26457,6 +26856,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0"
                                                       />
                                                        
@@ -26480,6 +26880,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0"
                     />
                      
@@ -26551,6 +26952,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.006"
                                                       />
                                                        
@@ -26574,6 +26976,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.006"
                     />
                      
@@ -26636,6 +27039,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.198937"
                                                       />
                                                        
@@ -26659,6 +27063,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.198937"
                     />
                      
@@ -26721,6 +27126,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.192937"
                                                       />
                                                        
@@ -26744,6 +27150,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.192937"
                     />
                      
@@ -26784,6 +27191,7 @@ ShallowWrapper {
                                         main={
                                                             <SelectableText>
                                                                                 <NumericText
+                                                                                                    maxDecimalPlaces={18}
                                                                                                     value="0.1"
                                                                                 />
                                                                                  
@@ -26816,6 +27224,7 @@ ShallowWrapper {
                                         main={
                                                             <SelectableText>
                                                                                 <NumericText
+                                                                                                    maxDecimalPlaces={18}
                                                                                                     value="0.1"
                                                                                 />
                                                                                  
@@ -26880,6 +27289,7 @@ ShallowWrapper {
                       main={
                                             <SelectableText>
                                                                   <NumericText
+                                                                                        maxDecimalPlaces={18}
                                                                                         value="0.1"
                                                                   />
                                                                    
@@ -26903,6 +27313,7 @@ ShallowWrapper {
                     "props": Object {
                       "main": <SelectableText>
                         <NumericText
+                                                maxDecimalPlaces={18}
                                                 value="0.1"
                         />
                          
@@ -26965,6 +27376,7 @@ ShallowWrapper {
                       main={
                                             <SelectableText>
                                                                   <NumericText
+                                                                                        maxDecimalPlaces={18}
                                                                                         value="0.1"
                                                                   />
                                                                    
@@ -26988,6 +27400,7 @@ ShallowWrapper {
                     "props": Object {
                       "main": <SelectableText>
                         <NumericText
+                                                maxDecimalPlaces={18}
                                                 value="0.1"
                         />
                          
@@ -27221,6 +27634,7 @@ ShallowWrapper {
                                         intl={
                                                   Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                                         }
                                         onChange={[Function]}
@@ -27257,6 +27671,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0"
                                                             />
                                                              
@@ -27291,6 +27706,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.006"
                                                             />
                                                              
@@ -27323,6 +27739,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.198937"
                                                             />
                                                              
@@ -27355,6 +27772,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.192937"
                                                             />
                                                              
@@ -27388,6 +27806,7 @@ ShallowWrapper {
                                                   main={
                                                             <SelectableText>
                                                                       <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.1"
                                                                       />
                                                                        
@@ -27420,6 +27839,7 @@ ShallowWrapper {
                                                   main={
                                                             <SelectableText>
                                                                       <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.1"
                                                                       />
                                                                        
@@ -27553,6 +27973,7 @@ ShallowWrapper {
                                           intl={
                                                         Object {
                                                                       "formatMessage": [Function],
+                                                                      "formatNumber": [Function],
                                                                     }
                                           }
                                           onChange={[Function]}
@@ -27589,6 +28010,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0"
                                                                       />
                                                                        
@@ -27623,6 +28045,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.006"
                                                                       />
                                                                        
@@ -27655,6 +28078,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.198937"
                                                                       />
                                                                        
@@ -27687,6 +28111,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.192937"
                                                                       />
                                                                        
@@ -27720,6 +28145,7 @@ ShallowWrapper {
                                                         main={
                                                                       <SelectableText>
                                                                                     <NumericText
+                                                                                                  maxDecimalPlaces={18}
                                                                                                   value="0.1"
                                                                                     />
                                                                                      
@@ -27752,6 +28178,7 @@ ShallowWrapper {
                                                         main={
                                                                       <SelectableText>
                                                                                     <NumericText
+                                                                                                  maxDecimalPlaces={18}
                                                                                                   value="0.1"
                                                                                     />
                                                                                      
@@ -27882,6 +28309,7 @@ ShallowWrapper {
                                 intl={
                                                 Object {
                                                                 "formatMessage": [Function],
+                                                                "formatNumber": [Function],
                                                               }
                                 }
                                 onChange={[Function]}
@@ -27971,6 +28399,7 @@ ShallowWrapper {
                     intl={
                                         Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                     }
                     onChange={[Function]}
@@ -28143,6 +28572,7 @@ ShallowWrapper {
                     "gasStatistics": undefined,
                     "intl": Object {
                       "formatMessage": [Function],
+                      "formatNumber": [Function],
                     },
                     "onChange": [Function],
                   },
@@ -28208,6 +28638,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0"
                                                                         />
                                                                          
@@ -28242,6 +28673,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.006"
                                                                         />
                                                                          
@@ -28274,6 +28706,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.198937"
                                                                         />
                                                                          
@@ -28306,6 +28739,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.192937"
                                                                         />
                                                                          
@@ -28339,6 +28773,7 @@ ShallowWrapper {
                                                       main={
                                                                         <SelectableText>
                                                                                           <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.1"
                                                                                           />
                                                                                            
@@ -28371,6 +28806,7 @@ ShallowWrapper {
                                                       main={
                                                                         <SelectableText>
                                                                                           <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.1"
                                                                                           />
                                                                                            
@@ -28464,6 +28900,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0"
                                                             />
                                                              
@@ -28487,6 +28924,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0"
                       />
                        
@@ -28558,6 +28996,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.006"
                                                             />
                                                              
@@ -28581,6 +29020,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.006"
                       />
                        
@@ -28643,6 +29083,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.198937"
                                                             />
                                                              
@@ -28666,6 +29107,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.198937"
                       />
                        
@@ -28728,6 +29170,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.192937"
                                                             />
                                                              
@@ -28751,6 +29194,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.192937"
                       />
                        
@@ -28791,6 +29235,7 @@ ShallowWrapper {
                                             main={
                                                                   <SelectableText>
                                                                                         <NumericText
+                                                                                                              maxDecimalPlaces={18}
                                                                                                               value="0.1"
                                                                                         />
                                                                                          
@@ -28823,6 +29268,7 @@ ShallowWrapper {
                                             main={
                                                                   <SelectableText>
                                                                                         <NumericText
+                                                                                                              maxDecimalPlaces={18}
                                                                                                               value="0.1"
                                                                                         />
                                                                                          
@@ -28887,6 +29333,7 @@ ShallowWrapper {
                         main={
                                                 <SelectableText>
                                                                         <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                         />
                                                                          
@@ -28910,6 +29357,7 @@ ShallowWrapper {
                       "props": Object {
                         "main": <SelectableText>
                           <NumericText
+                                                    maxDecimalPlaces={18}
                                                     value="0.1"
                           />
                            
@@ -28972,6 +29420,7 @@ ShallowWrapper {
                         main={
                                                 <SelectableText>
                                                                         <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                         />
                                                                          
@@ -28995,6 +29444,7 @@ ShallowWrapper {
                       "props": Object {
                         "main": <SelectableText>
                           <NumericText
+                                                    maxDecimalPlaces={18}
                                                     value="0.1"
                           />
                            
@@ -29645,6 +30095,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -30257,6 +30708,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -30897,6 +31349,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -31514,6 +31967,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -32159,6 +32613,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -32371,6 +32826,7 @@ ShallowWrapper {
                                 intl={
                                         Object {
                                                 "formatMessage": [Function],
+                                                "formatNumber": [Function],
                                               }
                                 }
                                 onChange={[Function]}
@@ -32407,6 +32863,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0"
                                                 />
                                                  
@@ -32441,6 +32898,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.006"
                                                 />
                                                  
@@ -32473,6 +32931,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.198937"
                                                 />
                                                  
@@ -32505,6 +32964,7 @@ ShallowWrapper {
                                 main={
                                         <SelectableText>
                                                 <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.192937"
                                                 />
                                                  
@@ -32538,6 +32998,7 @@ ShallowWrapper {
                                         main={
                                                 <SelectableText>
                                                         <NumericText
+                                                                maxDecimalPlaces={18}
                                                                 value="0.1"
                                                         />
                                                          
@@ -32570,6 +33031,7 @@ ShallowWrapper {
                                         main={
                                                 <SelectableText>
                                                         <NumericText
+                                                                maxDecimalPlaces={18}
                                                                 value="0.1"
                                                         />
                                                          
@@ -32703,6 +33165,7 @@ ShallowWrapper {
                                     intl={
                                                 Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                                     }
                                     onChange={[Function]}
@@ -32739,6 +33202,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0"
                                                             />
                                                              
@@ -32773,6 +33237,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.006"
                                                             />
                                                              
@@ -32805,6 +33270,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.198937"
                                                             />
                                                              
@@ -32837,6 +33303,7 @@ ShallowWrapper {
                                     main={
                                                 <SelectableText>
                                                             <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.192937"
                                                             />
                                                              
@@ -32870,6 +33337,7 @@ ShallowWrapper {
                                                 main={
                                                             <SelectableText>
                                                                         <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.1"
                                                                         />
                                                                          
@@ -32902,6 +33370,7 @@ ShallowWrapper {
                                                 main={
                                                             <SelectableText>
                                                                         <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.1"
                                                                         />
                                                                          
@@ -33032,6 +33501,7 @@ ShallowWrapper {
                             intl={
                                           Object {
                                                         "formatMessage": [Function],
+                                                        "formatNumber": [Function],
                                                       }
                             }
                             onChange={[Function]}
@@ -33121,6 +33591,7 @@ ShallowWrapper {
                   intl={
                                     Object {
                                                       "formatMessage": [Function],
+                                                      "formatNumber": [Function],
                                                     }
                   }
                   onChange={[Function]}
@@ -33293,6 +33764,7 @@ ShallowWrapper {
                   "gasStatistics": undefined,
                   "intl": Object {
                     "formatMessage": [Function],
+                    "formatNumber": [Function],
                   },
                   "onChange": [Function],
                 },
@@ -33358,6 +33830,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0"
                                                                 />
                                                                  
@@ -33392,6 +33865,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.006"
                                                                 />
                                                                  
@@ -33424,6 +33898,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.198937"
                                                                 />
                                                                  
@@ -33456,6 +33931,7 @@ ShallowWrapper {
                                 main={
                                                 <SelectableText>
                                                                 <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.192937"
                                                                 />
                                                                  
@@ -33489,6 +33965,7 @@ ShallowWrapper {
                                                 main={
                                                                 <SelectableText>
                                                                                 <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                                 />
                                                                                  
@@ -33521,6 +33998,7 @@ ShallowWrapper {
                                                 main={
                                                                 <SelectableText>
                                                                                 <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                                 />
                                                                                  
@@ -33614,6 +34092,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0"
                                                       />
                                                        
@@ -33637,6 +34116,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0"
                     />
                      
@@ -33708,6 +34188,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.006"
                                                       />
                                                        
@@ -33731,6 +34212,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.006"
                     />
                      
@@ -33793,6 +34275,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.198937"
                                                       />
                                                        
@@ -33816,6 +34299,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.198937"
                     />
                      
@@ -33878,6 +34362,7 @@ ShallowWrapper {
                   main={
                                     <SelectableText>
                                                       <NumericText
+                                                                        maxDecimalPlaces={18}
                                                                         value="0.192937"
                                                       />
                                                        
@@ -33901,6 +34386,7 @@ ShallowWrapper {
                 "props": Object {
                   "main": <SelectableText>
                     <NumericText
+                                        maxDecimalPlaces={18}
                                         value="0.192937"
                     />
                      
@@ -33941,6 +34427,7 @@ ShallowWrapper {
                                         main={
                                                             <SelectableText>
                                                                                 <NumericText
+                                                                                                    maxDecimalPlaces={18}
                                                                                                     value="0.1"
                                                                                 />
                                                                                  
@@ -33973,6 +34460,7 @@ ShallowWrapper {
                                         main={
                                                             <SelectableText>
                                                                                 <NumericText
+                                                                                                    maxDecimalPlaces={18}
                                                                                                     value="0.1"
                                                                                 />
                                                                                  
@@ -34037,6 +34525,7 @@ ShallowWrapper {
                       main={
                                             <SelectableText>
                                                                   <NumericText
+                                                                                        maxDecimalPlaces={18}
                                                                                         value="0.1"
                                                                   />
                                                                    
@@ -34060,6 +34549,7 @@ ShallowWrapper {
                     "props": Object {
                       "main": <SelectableText>
                         <NumericText
+                                                maxDecimalPlaces={18}
                                                 value="0.1"
                         />
                          
@@ -34122,6 +34612,7 @@ ShallowWrapper {
                       main={
                                             <SelectableText>
                                                                   <NumericText
+                                                                                        maxDecimalPlaces={18}
                                                                                         value="0.1"
                                                                   />
                                                                    
@@ -34145,6 +34636,7 @@ ShallowWrapper {
                     "props": Object {
                       "main": <SelectableText>
                         <NumericText
+                                                maxDecimalPlaces={18}
                                                 value="0.1"
                         />
                          
@@ -34378,6 +34870,7 @@ ShallowWrapper {
                                         intl={
                                                   Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                                         }
                                         onChange={[Function]}
@@ -34414,6 +34907,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0"
                                                             />
                                                              
@@ -34448,6 +34942,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.006"
                                                             />
                                                              
@@ -34480,6 +34975,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.198937"
                                                             />
                                                              
@@ -34512,6 +35008,7 @@ ShallowWrapper {
                                         main={
                                                   <SelectableText>
                                                             <NumericText
+                                                                      maxDecimalPlaces={18}
                                                                       value="0.192937"
                                                             />
                                                              
@@ -34545,6 +35042,7 @@ ShallowWrapper {
                                                   main={
                                                             <SelectableText>
                                                                       <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.1"
                                                                       />
                                                                        
@@ -34577,6 +35075,7 @@ ShallowWrapper {
                                                   main={
                                                             <SelectableText>
                                                                       <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.1"
                                                                       />
                                                                        
@@ -34710,6 +35209,7 @@ ShallowWrapper {
                                           intl={
                                                         Object {
                                                                       "formatMessage": [Function],
+                                                                      "formatNumber": [Function],
                                                                     }
                                           }
                                           onChange={[Function]}
@@ -34746,6 +35246,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0"
                                                                       />
                                                                        
@@ -34780,6 +35281,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.006"
                                                                       />
                                                                        
@@ -34812,6 +35314,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.198937"
                                                                       />
                                                                        
@@ -34844,6 +35347,7 @@ ShallowWrapper {
                                           main={
                                                         <SelectableText>
                                                                       <NumericText
+                                                                                    maxDecimalPlaces={18}
                                                                                     value="0.192937"
                                                                       />
                                                                        
@@ -34877,6 +35381,7 @@ ShallowWrapper {
                                                         main={
                                                                       <SelectableText>
                                                                                     <NumericText
+                                                                                                  maxDecimalPlaces={18}
                                                                                                   value="0.1"
                                                                                     />
                                                                                      
@@ -34909,6 +35414,7 @@ ShallowWrapper {
                                                         main={
                                                                       <SelectableText>
                                                                                     <NumericText
+                                                                                                  maxDecimalPlaces={18}
                                                                                                   value="0.1"
                                                                                     />
                                                                                      
@@ -35039,6 +35545,7 @@ ShallowWrapper {
                                 intl={
                                                 Object {
                                                                 "formatMessage": [Function],
+                                                                "formatNumber": [Function],
                                                               }
                                 }
                                 onChange={[Function]}
@@ -35128,6 +35635,7 @@ ShallowWrapper {
                     intl={
                                         Object {
                                                             "formatMessage": [Function],
+                                                            "formatNumber": [Function],
                                                           }
                     }
                     onChange={[Function]}
@@ -35300,6 +35808,7 @@ ShallowWrapper {
                     "gasStatistics": undefined,
                     "intl": Object {
                       "formatMessage": [Function],
+                      "formatNumber": [Function],
                     },
                     "onChange": [Function],
                   },
@@ -35365,6 +35874,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0"
                                                                         />
                                                                          
@@ -35399,6 +35909,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.006"
                                                                         />
                                                                          
@@ -35431,6 +35942,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.198937"
                                                                         />
                                                                          
@@ -35463,6 +35975,7 @@ ShallowWrapper {
                                     main={
                                                       <SelectableText>
                                                                         <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.192937"
                                                                         />
                                                                          
@@ -35496,6 +36009,7 @@ ShallowWrapper {
                                                       main={
                                                                         <SelectableText>
                                                                                           <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.1"
                                                                                           />
                                                                                            
@@ -35528,6 +36042,7 @@ ShallowWrapper {
                                                       main={
                                                                         <SelectableText>
                                                                                           <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.1"
                                                                                           />
                                                                                            
@@ -35621,6 +36136,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0"
                                                             />
                                                              
@@ -35644,6 +36160,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0"
                       />
                        
@@ -35715,6 +36232,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.006"
                                                             />
                                                              
@@ -35738,6 +36256,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.006"
                       />
                        
@@ -35800,6 +36319,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.198937"
                                                             />
                                                              
@@ -35823,6 +36343,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.198937"
                       />
                        
@@ -35885,6 +36406,7 @@ ShallowWrapper {
                     main={
                                         <SelectableText>
                                                             <NumericText
+                                                                                maxDecimalPlaces={18}
                                                                                 value="0.192937"
                                                             />
                                                              
@@ -35908,6 +36430,7 @@ ShallowWrapper {
                   "props": Object {
                     "main": <SelectableText>
                       <NumericText
+                                            maxDecimalPlaces={18}
                                             value="0.192937"
                       />
                        
@@ -35948,6 +36471,7 @@ ShallowWrapper {
                                             main={
                                                                   <SelectableText>
                                                                                         <NumericText
+                                                                                                              maxDecimalPlaces={18}
                                                                                                               value="0.1"
                                                                                         />
                                                                                          
@@ -35980,6 +36504,7 @@ ShallowWrapper {
                                             main={
                                                                   <SelectableText>
                                                                                         <NumericText
+                                                                                                              maxDecimalPlaces={18}
                                                                                                               value="0.1"
                                                                                         />
                                                                                          
@@ -36044,6 +36569,7 @@ ShallowWrapper {
                         main={
                                                 <SelectableText>
                                                                         <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                         />
                                                                          
@@ -36067,6 +36593,7 @@ ShallowWrapper {
                       "props": Object {
                         "main": <SelectableText>
                           <NumericText
+                                                    maxDecimalPlaces={18}
                                                     value="0.1"
                           />
                            
@@ -36129,6 +36656,7 @@ ShallowWrapper {
                         main={
                                                 <SelectableText>
                                                                         <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.1"
                                                                         />
                                                                          
@@ -36152,6 +36680,7 @@ ShallowWrapper {
                       "props": Object {
                         "main": <SelectableText>
                           <NumericText
+                                                    maxDecimalPlaces={18}
                                                     value="0.1"
                           />
                            

--- a/src/containers/NahmiiWithdraw/index.js
+++ b/src/containers/NahmiiWithdraw/index.js
@@ -673,7 +673,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                       </Row>
                       <Row>
                         <TransferDescriptionItem
-                          main={<SelectableText><NumericText value={transactionFee.amount.toString()} /> {'ETH'}</SelectableText>}
+                          main={<SelectableText><NumericText maxDecimalPlaces={18} value={transactionFee.amount.toString()} /> {'ETH'}</SelectableText>}
                           subtitle={<NumericText value={transactionFee.usdValue.toString()} type="currency" />}
                         />
                       </Row>
@@ -683,7 +683,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                       <Row>
                         <TransferDescriptionItem
                           className="base-layer-eth-balance-before"
-                          main={<SelectableText><NumericText value={baseLayerEthBalanceBefore.amount.toString()} /> {'ETH'}</SelectableText>}
+                          main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerEthBalanceBefore.amount.toString()} /> {'ETH'}</SelectableText>}
                           subtitle={<NumericText value={baseLayerEthBalanceBefore.usdValue.toString()} type="currency" />}
                         />
                       </Row>
@@ -695,7 +695,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                       <Row>
                         <TransferDescriptionItem
                           className="base-layer-eth-balance-after"
-                          main={<SelectableText><NumericText value={baseLayerEthBalanceAfter.amount.toString()} /> {'ETH'}</SelectableText>}
+                          main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerEthBalanceAfter.amount.toString()} /> {'ETH'}</SelectableText>}
                           subtitle={<NumericText value={baseLayerEthBalanceAfter.usdValue.toString()} type="currency" />}
                         />
                       </Row>
@@ -704,7 +704,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                       </Row>
                       <Row>
                         <TransferDescriptionItem
-                          main={<SelectableText><NumericText value={requiredSettlementAmount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
+                          main={<SelectableText><NumericText maxDecimalPlaces={18} value={requiredSettlementAmount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
                           subtitle={<NumericText value={requiredSettlementAmount.times(assetToWithdrawUsdValue).toString()} type="currency" />}
                         />
                       </Row>
@@ -714,7 +714,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                       <Row>
                         <TransferDescriptionItem
                           className="nahmii-balance-before-staging"
-                          main={<SelectableText><NumericText value={nahmiiBalanceBefore.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
+                          main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiBalanceBefore.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
                           subtitle={<NumericText value={nahmiiBalanceBefore.usdValue.toString()} type="currency" />}
                         />
                       </Row>
@@ -726,7 +726,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                       <Row>
                         <TransferDescriptionItem
                           className="nahmii-balance-after-staging"
-                          main={<SelectableText><NumericText value={nahmiiBalanceAfterStaging.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
+                          main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiBalanceAfterStaging.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
                           subtitle={<NumericText value={nahmiiBalanceAfterStaging.usdValue.toString()} type="currency" />}
                         />
                       </Row>
@@ -754,7 +754,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                       </Row>
                       <Row>
                         <TransferDescriptionItem
-                          main={<SelectableText><NumericText value={amountToWithdraw.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
+                          main={<SelectableText><NumericText maxDecimalPlaces={18} value={amountToWithdraw.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
                           subtitle={<NumericText value={usdValueToWithdraw.toString()} type="currency" />}
                         />
                       </Row>
@@ -767,7 +767,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                       </Row>
                       <Row>
                         <TransferDescriptionItem
-                          main={<SelectableText><NumericText value={transactionFee.amount.toString()} /> {'ETH'}</SelectableText>}
+                          main={<SelectableText><NumericText maxDecimalPlaces={18} value={transactionFee.amount.toString()} /> {'ETH'}</SelectableText>}
                           subtitle={<NumericText value={transactionFee.usdValue.toString()} type="currency" />}
                         />
                       </Row>
@@ -777,7 +777,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                       <Row>
                         <TransferDescriptionItem
                           className="base-layer-eth-balance-before"
-                          main={<SelectableText><NumericText value={baseLayerEthBalanceBefore.amount.toString()} /> {'ETH'}</SelectableText>}
+                          main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerEthBalanceBefore.amount.toString()} /> {'ETH'}</SelectableText>}
                           subtitle={<NumericText value={baseLayerEthBalanceBefore.usdValue.toString()} type="currency" />}
                         />
                       </Row>
@@ -789,7 +789,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                       <Row>
                         <TransferDescriptionItem
                           className="base-layer-eth-balance-after"
-                          main={<SelectableText><NumericText value={baseLayerEthBalanceAfter.amount.toString()} /> {'ETH'}</SelectableText>}
+                          main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerEthBalanceAfter.amount.toString()} /> {'ETH'}</SelectableText>}
                           subtitle={<NumericText value={baseLayerEthBalanceAfter.usdValue.toString()} type="currency" />}
                         />
                       </Row>
@@ -801,7 +801,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                         <Row>
                           <TransferDescriptionItem
                             className="staged-balance-before"
-                            main={<SelectableText><NumericText value={nahmiiStagedBalanceBefore.amount.toString()} /> {'ETH'}</SelectableText>}
+                            main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiStagedBalanceBefore.amount.toString()} /> {'ETH'}</SelectableText>}
                             subtitle={<NumericText value={nahmiiStagedBalanceBefore.usdValue.toString()} type="currency" />}
                           />
                         </Row>
@@ -813,7 +813,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                         <Row>
                           <TransferDescriptionItem
                             className="staged-balance-after"
-                            main={<SelectableText><NumericText value={nahmiiStagedBalanceAfter.amount.toString()} /> {'ETH'}</SelectableText>}
+                            main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiStagedBalanceAfter.amount.toString()} /> {'ETH'}</SelectableText>}
                             subtitle={<NumericText value={nahmiiStagedBalanceAfter.usdValue.toString()} type="currency" />}
                           />
                         </Row>
@@ -827,7 +827,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                         <Row>
                           <TransferDescriptionItem
                             className="base-layer-token-balance-before"
-                            main={<SelectableText><NumericText value={baseLayerBalanceBefore.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
+                            main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerBalanceBefore.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
                             subtitle={<NumericText value={baseLayerBalanceBefore.usdValue.toString()} type="currency" />}
                           />
                         </Row>
@@ -839,7 +839,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                         <Row>
                           <TransferDescriptionItem
                             className="base-layer-token-balance-after"
-                            main={<SelectableText><NumericText value={baseLayerBalanceAfter.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
+                            main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerBalanceAfter.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
                             subtitle={<NumericText value={baseLayerBalanceAfter.usdValue.toString()} type="currency" />}
                           />
                         </Row>
@@ -849,7 +849,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                         <Row>
                           <TransferDescriptionItem
                             className="staged-balance-before"
-                            main={<SelectableText><NumericText value={nahmiiStagedBalanceBefore.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
+                            main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiStagedBalanceBefore.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
                             subtitle={<NumericText value={nahmiiStagedBalanceBefore.usdValue.toString()} type="currency" />}
                           />
                         </Row>
@@ -861,7 +861,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                         <Row>
                           <TransferDescriptionItem
                             className="staged-balance-after"
-                            main={<SelectableText><NumericText value={nahmiiStagedBalanceAfter.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
+                            main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiStagedBalanceAfter.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
                             subtitle={<NumericText value={nahmiiStagedBalanceAfter.usdValue.toString()} type="currency" />}
                           />
                         </Row>

--- a/src/containers/NahmiiWithdraw/index.js
+++ b/src/containers/NahmiiWithdraw/index.js
@@ -674,7 +674,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                       <Row>
                         <TransferDescriptionItem
                           main={<SelectableText><NumericText maxDecimalPlaces={18} value={transactionFee.amount.toString()} /> {'ETH'}</SelectableText>}
-                          subtitle={<NumericText value={transactionFee.usdValue.toString()} type="currency" />}
+                          subtitle={<NumericText value={transactionFee.usdValue.toString()} type="fiat" />}
                         />
                       </Row>
                       <Row>
@@ -684,7 +684,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                         <TransferDescriptionItem
                           className="base-layer-eth-balance-before"
                           main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerEthBalanceBefore.amount.toString()} /> {'ETH'}</SelectableText>}
-                          subtitle={<NumericText value={baseLayerEthBalanceBefore.usdValue.toString()} type="currency" />}
+                          subtitle={<NumericText value={baseLayerEthBalanceBefore.usdValue.toString()} type="fiat" />}
                         />
                       </Row>
                       <Row>
@@ -696,7 +696,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                         <TransferDescriptionItem
                           className="base-layer-eth-balance-after"
                           main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerEthBalanceAfter.amount.toString()} /> {'ETH'}</SelectableText>}
-                          subtitle={<NumericText value={baseLayerEthBalanceAfter.usdValue.toString()} type="currency" />}
+                          subtitle={<NumericText value={baseLayerEthBalanceAfter.usdValue.toString()} type="fiat" />}
                         />
                       </Row>
                       <Row>
@@ -705,7 +705,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                       <Row>
                         <TransferDescriptionItem
                           main={<SelectableText><NumericText maxDecimalPlaces={18} value={requiredSettlementAmount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
-                          subtitle={<NumericText value={requiredSettlementAmount.times(assetToWithdrawUsdValue).toString()} type="currency" />}
+                          subtitle={<NumericText value={requiredSettlementAmount.times(assetToWithdrawUsdValue).toString()} type="fiat" />}
                         />
                       </Row>
                       <Row>
@@ -715,7 +715,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                         <TransferDescriptionItem
                           className="nahmii-balance-before-staging"
                           main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiBalanceBefore.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
-                          subtitle={<NumericText value={nahmiiBalanceBefore.usdValue.toString()} type="currency" />}
+                          subtitle={<NumericText value={nahmiiBalanceBefore.usdValue.toString()} type="fiat" />}
                         />
                       </Row>
                       <Row>
@@ -727,7 +727,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                         <TransferDescriptionItem
                           className="nahmii-balance-after-staging"
                           main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiBalanceAfterStaging.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
-                          subtitle={<NumericText value={nahmiiBalanceAfterStaging.usdValue.toString()} type="currency" />}
+                          subtitle={<NumericText value={nahmiiBalanceAfterStaging.usdValue.toString()} type="fiat" />}
                         />
                       </Row>
                       <Row>
@@ -755,7 +755,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                       <Row>
                         <TransferDescriptionItem
                           main={<SelectableText><NumericText maxDecimalPlaces={18} value={amountToWithdraw.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
-                          subtitle={<NumericText value={usdValueToWithdraw.toString()} type="currency" />}
+                          subtitle={<NumericText value={usdValueToWithdraw.toString()} type="fiat" />}
                         />
                       </Row>
                       <Row>
@@ -768,7 +768,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                       <Row>
                         <TransferDescriptionItem
                           main={<SelectableText><NumericText maxDecimalPlaces={18} value={transactionFee.amount.toString()} /> {'ETH'}</SelectableText>}
-                          subtitle={<NumericText value={transactionFee.usdValue.toString()} type="currency" />}
+                          subtitle={<NumericText value={transactionFee.usdValue.toString()} type="fiat" />}
                         />
                       </Row>
                       <Row>
@@ -778,7 +778,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                         <TransferDescriptionItem
                           className="base-layer-eth-balance-before"
                           main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerEthBalanceBefore.amount.toString()} /> {'ETH'}</SelectableText>}
-                          subtitle={<NumericText value={baseLayerEthBalanceBefore.usdValue.toString()} type="currency" />}
+                          subtitle={<NumericText value={baseLayerEthBalanceBefore.usdValue.toString()} type="fiat" />}
                         />
                       </Row>
                       <Row>
@@ -790,7 +790,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                         <TransferDescriptionItem
                           className="base-layer-eth-balance-after"
                           main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerEthBalanceAfter.amount.toString()} /> {'ETH'}</SelectableText>}
-                          subtitle={<NumericText value={baseLayerEthBalanceAfter.usdValue.toString()} type="currency" />}
+                          subtitle={<NumericText value={baseLayerEthBalanceAfter.usdValue.toString()} type="fiat" />}
                         />
                       </Row>
                       {assetToWithdraw.symbol === 'ETH' &&
@@ -802,7 +802,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                           <TransferDescriptionItem
                             className="staged-balance-before"
                             main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiStagedBalanceBefore.amount.toString()} /> {'ETH'}</SelectableText>}
-                            subtitle={<NumericText value={nahmiiStagedBalanceBefore.usdValue.toString()} type="currency" />}
+                            subtitle={<NumericText value={nahmiiStagedBalanceBefore.usdValue.toString()} type="fiat" />}
                           />
                         </Row>
                         <Row>
@@ -814,7 +814,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                           <TransferDescriptionItem
                             className="staged-balance-after"
                             main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiStagedBalanceAfter.amount.toString()} /> {'ETH'}</SelectableText>}
-                            subtitle={<NumericText value={nahmiiStagedBalanceAfter.usdValue.toString()} type="currency" />}
+                            subtitle={<NumericText value={nahmiiStagedBalanceAfter.usdValue.toString()} type="fiat" />}
                           />
                         </Row>
                       </div>
@@ -828,7 +828,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                           <TransferDescriptionItem
                             className="base-layer-token-balance-before"
                             main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerBalanceBefore.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
-                            subtitle={<NumericText value={baseLayerBalanceBefore.usdValue.toString()} type="currency" />}
+                            subtitle={<NumericText value={baseLayerBalanceBefore.usdValue.toString()} type="fiat" />}
                           />
                         </Row>
                         <Row>
@@ -840,7 +840,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                           <TransferDescriptionItem
                             className="base-layer-token-balance-after"
                             main={<SelectableText><NumericText maxDecimalPlaces={18} value={baseLayerBalanceAfter.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
-                            subtitle={<NumericText value={baseLayerBalanceAfter.usdValue.toString()} type="currency" />}
+                            subtitle={<NumericText value={baseLayerBalanceAfter.usdValue.toString()} type="fiat" />}
                           />
                         </Row>
                         <Row>
@@ -850,7 +850,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                           <TransferDescriptionItem
                             className="staged-balance-before"
                             main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiStagedBalanceBefore.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
-                            subtitle={<NumericText value={nahmiiStagedBalanceBefore.usdValue.toString()} type="currency" />}
+                            subtitle={<NumericText value={nahmiiStagedBalanceBefore.usdValue.toString()} type="fiat" />}
                           />
                         </Row>
                         <Row>
@@ -862,7 +862,7 @@ export class NahmiiWithdraw extends React.Component { // eslint-disable-line rea
                           <TransferDescriptionItem
                             className="staged-balance-after"
                             main={<SelectableText><NumericText maxDecimalPlaces={18} value={nahmiiStagedBalanceAfter.amount.toString()} /> {assetToWithdraw.symbol}</SelectableText>}
-                            subtitle={<NumericText value={nahmiiStagedBalanceAfter.usdValue.toString()} type="currency" />}
+                            subtitle={<NumericText value={nahmiiStagedBalanceAfter.usdValue.toString()} type="fiat" />}
                           />
                         </Row>
                       </div>

--- a/src/containers/NahmiiWithdraw/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/NahmiiWithdraw/tests/__snapshots__/index.test.js.snap
@@ -782,7 +782,7 @@ ShallowWrapper {
                                                             }
                                                             subtitle={
                                                                       <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="0"
                                                                       />
                                                             }
@@ -817,7 +817,7 @@ ShallowWrapper {
                                                             }
                                                             subtitle={
                                                                       <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="24.72"
                                                                       />
                                                             }
@@ -851,7 +851,7 @@ ShallowWrapper {
                                                             }
                                                             subtitle={
                                                                       <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="81.962044"
                                                                       />
                                                             }
@@ -885,7 +885,7 @@ ShallowWrapper {
                                                             }
                                                             subtitle={
                                                                       <NumericText
-                                                                                type="currency"
+                                                                                type="fiat"
                                                                                 value="57.242044"
                                                                       />
                                                             }
@@ -920,7 +920,7 @@ ShallowWrapper {
                                                                       }
                                                                       subtitle={
                                                                                 <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="0"
                                                                                 />
                                                                       }
@@ -954,7 +954,7 @@ ShallowWrapper {
                                                                       }
                                                                       subtitle={
                                                                                 <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="0"
                                                                                 />
                                                                       }
@@ -1141,7 +1141,7 @@ ShallowWrapper {
                                                             }
                                                             subtitle={
                                                                         <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="0"
                                                                         />
                                                             }
@@ -1176,7 +1176,7 @@ ShallowWrapper {
                                                             }
                                                             subtitle={
                                                                         <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="24.72"
                                                                         />
                                                             }
@@ -1210,7 +1210,7 @@ ShallowWrapper {
                                                             }
                                                             subtitle={
                                                                         <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="81.962044"
                                                                         />
                                                             }
@@ -1244,7 +1244,7 @@ ShallowWrapper {
                                                             }
                                                             subtitle={
                                                                         <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="57.242044"
                                                                         />
                                                             }
@@ -1279,7 +1279,7 @@ ShallowWrapper {
                                                                         }
                                                                         subtitle={
                                                                                     <NumericText
-                                                                                                type="currency"
+                                                                                                type="fiat"
                                                                                                 value="0"
                                                                                     />
                                                                         }
@@ -1313,7 +1313,7 @@ ShallowWrapper {
                                                                         }
                                                                         subtitle={
                                                                                     <NumericText
-                                                                                                type="currency"
+                                                                                                type="fiat"
                                                                                                 value="0"
                                                                                     />
                                                                         }
@@ -1480,7 +1480,7 @@ ShallowWrapper {
                                                                 }
                                                                 subtitle={
                                                                                 <NumericText
-                                                                                                type="currency"
+                                                                                                type="fiat"
                                                                                                 value="0"
                                                                                 />
                                                                 }
@@ -1515,7 +1515,7 @@ ShallowWrapper {
                                                                 }
                                                                 subtitle={
                                                                                 <NumericText
-                                                                                                type="currency"
+                                                                                                type="fiat"
                                                                                                 value="24.72"
                                                                                 />
                                                                 }
@@ -1549,7 +1549,7 @@ ShallowWrapper {
                                                                 }
                                                                 subtitle={
                                                                                 <NumericText
-                                                                                                type="currency"
+                                                                                                type="fiat"
                                                                                                 value="81.962044"
                                                                                 />
                                                                 }
@@ -1583,7 +1583,7 @@ ShallowWrapper {
                                                                 }
                                                                 subtitle={
                                                                                 <NumericText
-                                                                                                type="currency"
+                                                                                                type="fiat"
                                                                                                 value="57.242044"
                                                                                 />
                                                                 }
@@ -1618,7 +1618,7 @@ ShallowWrapper {
                                                                                 }
                                                                                 subtitle={
                                                                                                 <NumericText
-                                                                                                                type="currency"
+                                                                                                                type="fiat"
                                                                                                                 value="0"
                                                                                                 />
                                                                                 }
@@ -1652,7 +1652,7 @@ ShallowWrapper {
                                                                                 }
                                                                                 subtitle={
                                                                                                 <NumericText
-                                                                                                                type="currency"
+                                                                                                                type="fiat"
                                                                                                                 value="0"
                                                                                                 />
                                                                                 }
@@ -2086,7 +2086,7 @@ ShallowWrapper {
                                                             }
                                                             subtitle={
                                                                                 <NumericText
-                                                                                                    type="currency"
+                                                                                                    type="fiat"
                                                                                                     value="0"
                                                                                 />
                                                             }
@@ -2121,7 +2121,7 @@ ShallowWrapper {
                                                             }
                                                             subtitle={
                                                                                 <NumericText
-                                                                                                    type="currency"
+                                                                                                    type="fiat"
                                                                                                     value="24.72"
                                                                                 />
                                                             }
@@ -2155,7 +2155,7 @@ ShallowWrapper {
                                                             }
                                                             subtitle={
                                                                                 <NumericText
-                                                                                                    type="currency"
+                                                                                                    type="fiat"
                                                                                                     value="81.962044"
                                                                                 />
                                                             }
@@ -2189,7 +2189,7 @@ ShallowWrapper {
                                                             }
                                                             subtitle={
                                                                                 <NumericText
-                                                                                                    type="currency"
+                                                                                                    type="fiat"
                                                                                                     value="57.242044"
                                                                                 />
                                                             }
@@ -2224,7 +2224,7 @@ ShallowWrapper {
                                                                                 }
                                                                                 subtitle={
                                                                                                     <NumericText
-                                                                                                                        type="currency"
+                                                                                                                        type="fiat"
                                                                                                                         value="0"
                                                                                                     />
                                                                                 }
@@ -2258,7 +2258,7 @@ ShallowWrapper {
                                                                                 }
                                                                                 subtitle={
                                                                                                     <NumericText
-                                                                                                                        type="currency"
+                                                                                                                        type="fiat"
                                                                                                                         value="0"
                                                                                                     />
                                                                                 }
@@ -2329,7 +2329,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                         <NumericText
-                                                                                                type="currency"
+                                                                                                type="fiat"
                                                                                                 value="0"
                                                                         />
                                                 }
@@ -2364,7 +2364,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                         <NumericText
-                                                                                                type="currency"
+                                                                                                type="fiat"
                                                                                                 value="24.72"
                                                                         />
                                                 }
@@ -2398,7 +2398,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                         <NumericText
-                                                                                                type="currency"
+                                                                                                type="fiat"
                                                                                                 value="81.962044"
                                                                         />
                                                 }
@@ -2432,7 +2432,7 @@ ShallowWrapper {
                                                 }
                                                 subtitle={
                                                                         <NumericText
-                                                                                                type="currency"
+                                                                                                type="fiat"
                                                                                                 value="57.242044"
                                                                         />
                                                 }
@@ -2467,7 +2467,7 @@ ShallowWrapper {
                                                                         }
                                                                         subtitle={
                                                                                                 <NumericText
-                                                                                                                        type="currency"
+                                                                                                                        type="fiat"
                                                                                                                         value="0"
                                                                                                 />
                                                                         }
@@ -2501,7 +2501,7 @@ ShallowWrapper {
                                                                         }
                                                                         subtitle={
                                                                                                 <NumericText
-                                                                                                                        type="currency"
+                                                                                                                        type="fiat"
                                                                                                                         value="0"
                                                                                                 />
                                                                         }
@@ -2594,7 +2594,7 @@ ShallowWrapper {
                           }
                           subtitle={
                                                     <NumericText
-                                                                              type="currency"
+                                                                              type="fiat"
                                                                               value="0"
                                                     />
                           }
@@ -2616,7 +2616,7 @@ ShallowWrapper {
                             ETH
 </SelectableText>,
                           "subtitle": <NumericText
-                            type="currency"
+                            type="fiat"
                             value="0"
 />,
                         },
@@ -2690,7 +2690,7 @@ ShallowWrapper {
                           }
                           subtitle={
                                                     <NumericText
-                                                                              type="currency"
+                                                                              type="fiat"
                                                                               value="24.72"
                                                     />
                           }
@@ -2712,7 +2712,7 @@ ShallowWrapper {
                             ETH
 </SelectableText>,
                           "subtitle": <NumericText
-                            type="currency"
+                            type="fiat"
                             value="24.72"
 />,
                         },
@@ -2778,7 +2778,7 @@ ShallowWrapper {
                           }
                           subtitle={
                                                     <NumericText
-                                                                              type="currency"
+                                                                              type="fiat"
                                                                               value="81.962044"
                                                     />
                           }
@@ -2801,7 +2801,7 @@ ShallowWrapper {
                             ETH
 </SelectableText>,
                           "subtitle": <NumericText
-                            type="currency"
+                            type="fiat"
                             value="81.962044"
 />,
                         },
@@ -2867,7 +2867,7 @@ ShallowWrapper {
                           }
                           subtitle={
                                                     <NumericText
-                                                                              type="currency"
+                                                                              type="fiat"
                                                                               value="57.242044"
                                                     />
                           }
@@ -2890,7 +2890,7 @@ ShallowWrapper {
                             ETH
 </SelectableText>,
                           "subtitle": <NumericText
-                            type="currency"
+                            type="fiat"
                             value="57.242044"
 />,
                         },
@@ -2934,7 +2934,7 @@ ShallowWrapper {
                                                         }
                                                         subtitle={
                                                                                     <NumericText
-                                                                                                                type="currency"
+                                                                                                                type="fiat"
                                                                                                                 value="0"
                                                                                     />
                                                         }
@@ -2968,7 +2968,7 @@ ShallowWrapper {
                                                         }
                                                         subtitle={
                                                                                     <NumericText
-                                                                                                                type="currency"
+                                                                                                                type="fiat"
                                                                                                                 value="0"
                                                                                     />
                                                         }
@@ -3034,7 +3034,7 @@ ShallowWrapper {
                               }
                               subtitle={
                                                             <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="0"
                                                             />
                               }
@@ -3057,7 +3057,7 @@ ShallowWrapper {
                                 ETH
 </SelectableText>,
                               "subtitle": <NumericText
-                                type="currency"
+                                type="fiat"
                                 value="0"
 />,
                             },
@@ -3123,7 +3123,7 @@ ShallowWrapper {
                               }
                               subtitle={
                                                             <NumericText
-                                                                                          type="currency"
+                                                                                          type="fiat"
                                                                                           value="0"
                                                             />
                               }
@@ -3146,7 +3146,7 @@ ShallowWrapper {
                                 ETH
 </SelectableText>,
                               "subtitle": <NumericText
-                                type="currency"
+                                type="fiat"
                                 value="0"
 />,
                             },
@@ -3430,7 +3430,7 @@ ShallowWrapper {
                                                                         }
                                                                         subtitle={
                                                                                     <NumericText
-                                                                                                type="currency"
+                                                                                                type="fiat"
                                                                                                 value="0"
                                                                                     />
                                                                         }
@@ -3465,7 +3465,7 @@ ShallowWrapper {
                                                                         }
                                                                         subtitle={
                                                                                     <NumericText
-                                                                                                type="currency"
+                                                                                                type="fiat"
                                                                                                 value="24.72"
                                                                                     />
                                                                         }
@@ -3499,7 +3499,7 @@ ShallowWrapper {
                                                                         }
                                                                         subtitle={
                                                                                     <NumericText
-                                                                                                type="currency"
+                                                                                                type="fiat"
                                                                                                 value="81.962044"
                                                                                     />
                                                                         }
@@ -3533,7 +3533,7 @@ ShallowWrapper {
                                                                         }
                                                                         subtitle={
                                                                                     <NumericText
-                                                                                                type="currency"
+                                                                                                type="fiat"
                                                                                                 value="57.242044"
                                                                                     />
                                                                         }
@@ -3568,7 +3568,7 @@ ShallowWrapper {
                                                                                     }
                                                                                     subtitle={
                                                                                                 <NumericText
-                                                                                                            type="currency"
+                                                                                                            type="fiat"
                                                                                                             value="0"
                                                                                                 />
                                                                                     }
@@ -3602,7 +3602,7 @@ ShallowWrapper {
                                                                                     }
                                                                                     subtitle={
                                                                                                 <NumericText
-                                                                                                            type="currency"
+                                                                                                            type="fiat"
                                                                                                             value="0"
                                                                                                 />
                                                                                     }
@@ -3789,7 +3789,7 @@ ShallowWrapper {
                                                                       }
                                                                       subtitle={
                                                                                     <NumericText
-                                                                                                  type="currency"
+                                                                                                  type="fiat"
                                                                                                   value="0"
                                                                                     />
                                                                       }
@@ -3824,7 +3824,7 @@ ShallowWrapper {
                                                                       }
                                                                       subtitle={
                                                                                     <NumericText
-                                                                                                  type="currency"
+                                                                                                  type="fiat"
                                                                                                   value="24.72"
                                                                                     />
                                                                       }
@@ -3858,7 +3858,7 @@ ShallowWrapper {
                                                                       }
                                                                       subtitle={
                                                                                     <NumericText
-                                                                                                  type="currency"
+                                                                                                  type="fiat"
                                                                                                   value="81.962044"
                                                                                     />
                                                                       }
@@ -3892,7 +3892,7 @@ ShallowWrapper {
                                                                       }
                                                                       subtitle={
                                                                                     <NumericText
-                                                                                                  type="currency"
+                                                                                                  type="fiat"
                                                                                                   value="57.242044"
                                                                                     />
                                                                       }
@@ -3927,7 +3927,7 @@ ShallowWrapper {
                                                                                     }
                                                                                     subtitle={
                                                                                                   <NumericText
-                                                                                                                type="currency"
+                                                                                                                type="fiat"
                                                                                                                 value="0"
                                                                                                   />
                                                                                     }
@@ -3961,7 +3961,7 @@ ShallowWrapper {
                                                                                     }
                                                                                     subtitle={
                                                                                                   <NumericText
-                                                                                                                type="currency"
+                                                                                                                type="fiat"
                                                                                                                 value="0"
                                                                                                   />
                                                                                     }
@@ -4128,7 +4128,7 @@ ShallowWrapper {
                                                                         }
                                                                         subtitle={
                                                                                           <NumericText
-                                                                                                            type="currency"
+                                                                                                            type="fiat"
                                                                                                             value="0"
                                                                                           />
                                                                         }
@@ -4163,7 +4163,7 @@ ShallowWrapper {
                                                                         }
                                                                         subtitle={
                                                                                           <NumericText
-                                                                                                            type="currency"
+                                                                                                            type="fiat"
                                                                                                             value="24.72"
                                                                                           />
                                                                         }
@@ -4197,7 +4197,7 @@ ShallowWrapper {
                                                                         }
                                                                         subtitle={
                                                                                           <NumericText
-                                                                                                            type="currency"
+                                                                                                            type="fiat"
                                                                                                             value="81.962044"
                                                                                           />
                                                                         }
@@ -4231,7 +4231,7 @@ ShallowWrapper {
                                                                         }
                                                                         subtitle={
                                                                                           <NumericText
-                                                                                                            type="currency"
+                                                                                                            type="fiat"
                                                                                                             value="57.242044"
                                                                                           />
                                                                         }
@@ -4266,7 +4266,7 @@ ShallowWrapper {
                                                                                           }
                                                                                           subtitle={
                                                                                                             <NumericText
-                                                                                                                              type="currency"
+                                                                                                                              type="fiat"
                                                                                                                               value="0"
                                                                                                             />
                                                                                           }
@@ -4300,7 +4300,7 @@ ShallowWrapper {
                                                                                           }
                                                                                           subtitle={
                                                                                                             <NumericText
-                                                                                                                              type="currency"
+                                                                                                                              type="fiat"
                                                                                                                               value="0"
                                                                                                             />
                                                                                           }
@@ -4734,7 +4734,7 @@ ShallowWrapper {
                                                                   }
                                                                   subtitle={
                                                                                         <NumericText
-                                                                                                              type="currency"
+                                                                                                              type="fiat"
                                                                                                               value="0"
                                                                                         />
                                                                   }
@@ -4769,7 +4769,7 @@ ShallowWrapper {
                                                                   }
                                                                   subtitle={
                                                                                         <NumericText
-                                                                                                              type="currency"
+                                                                                                              type="fiat"
                                                                                                               value="24.72"
                                                                                         />
                                                                   }
@@ -4803,7 +4803,7 @@ ShallowWrapper {
                                                                   }
                                                                   subtitle={
                                                                                         <NumericText
-                                                                                                              type="currency"
+                                                                                                              type="fiat"
                                                                                                               value="81.962044"
                                                                                         />
                                                                   }
@@ -4837,7 +4837,7 @@ ShallowWrapper {
                                                                   }
                                                                   subtitle={
                                                                                         <NumericText
-                                                                                                              type="currency"
+                                                                                                              type="fiat"
                                                                                                               value="57.242044"
                                                                                         />
                                                                   }
@@ -4872,7 +4872,7 @@ ShallowWrapper {
                                                                                         }
                                                                                         subtitle={
                                                                                                               <NumericText
-                                                                                                                                    type="currency"
+                                                                                                                                    type="fiat"
                                                                                                                                     value="0"
                                                                                                               />
                                                                                         }
@@ -4906,7 +4906,7 @@ ShallowWrapper {
                                                                                         }
                                                                                         subtitle={
                                                                                                               <NumericText
-                                                                                                                                    type="currency"
+                                                                                                                                    type="fiat"
                                                                                                                                     value="0"
                                                                                                               />
                                                                                         }
@@ -4977,7 +4977,7 @@ ShallowWrapper {
                                                     }
                                                     subtitle={
                                                                               <NumericText
-                                                                                                        type="currency"
+                                                                                                        type="fiat"
                                                                                                         value="0"
                                                                               />
                                                     }
@@ -5012,7 +5012,7 @@ ShallowWrapper {
                                                     }
                                                     subtitle={
                                                                               <NumericText
-                                                                                                        type="currency"
+                                                                                                        type="fiat"
                                                                                                         value="24.72"
                                                                               />
                                                     }
@@ -5046,7 +5046,7 @@ ShallowWrapper {
                                                     }
                                                     subtitle={
                                                                               <NumericText
-                                                                                                        type="currency"
+                                                                                                        type="fiat"
                                                                                                         value="81.962044"
                                                                               />
                                                     }
@@ -5080,7 +5080,7 @@ ShallowWrapper {
                                                     }
                                                     subtitle={
                                                                               <NumericText
-                                                                                                        type="currency"
+                                                                                                        type="fiat"
                                                                                                         value="57.242044"
                                                                               />
                                                     }
@@ -5115,7 +5115,7 @@ ShallowWrapper {
                                                                               }
                                                                               subtitle={
                                                                                                         <NumericText
-                                                                                                                                  type="currency"
+                                                                                                                                  type="fiat"
                                                                                                                                   value="0"
                                                                                                         />
                                                                               }
@@ -5149,7 +5149,7 @@ ShallowWrapper {
                                                                               }
                                                                               subtitle={
                                                                                                         <NumericText
-                                                                                                                                  type="currency"
+                                                                                                                                  type="fiat"
                                                                                                                                   value="0"
                                                                                                         />
                                                                               }
@@ -5242,7 +5242,7 @@ ShallowWrapper {
                             }
                             subtitle={
                                                         <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="0"
                                                         />
                             }
@@ -5264,7 +5264,7 @@ ShallowWrapper {
                               ETH
 </SelectableText>,
                             "subtitle": <NumericText
-                              type="currency"
+                              type="fiat"
                               value="0"
 />,
                           },
@@ -5338,7 +5338,7 @@ ShallowWrapper {
                             }
                             subtitle={
                                                         <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="24.72"
                                                         />
                             }
@@ -5360,7 +5360,7 @@ ShallowWrapper {
                               ETH
 </SelectableText>,
                             "subtitle": <NumericText
-                              type="currency"
+                              type="fiat"
                               value="24.72"
 />,
                           },
@@ -5426,7 +5426,7 @@ ShallowWrapper {
                             }
                             subtitle={
                                                         <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="81.962044"
                                                         />
                             }
@@ -5449,7 +5449,7 @@ ShallowWrapper {
                               ETH
 </SelectableText>,
                             "subtitle": <NumericText
-                              type="currency"
+                              type="fiat"
                               value="81.962044"
 />,
                           },
@@ -5515,7 +5515,7 @@ ShallowWrapper {
                             }
                             subtitle={
                                                         <NumericText
-                                                                                    type="currency"
+                                                                                    type="fiat"
                                                                                     value="57.242044"
                                                         />
                             }
@@ -5538,7 +5538,7 @@ ShallowWrapper {
                               ETH
 </SelectableText>,
                             "subtitle": <NumericText
-                              type="currency"
+                              type="fiat"
                               value="57.242044"
 />,
                           },
@@ -5582,7 +5582,7 @@ ShallowWrapper {
                                                             }
                                                             subtitle={
                                                                                           <NumericText
-                                                                                                                        type="currency"
+                                                                                                                        type="fiat"
                                                                                                                         value="0"
                                                                                           />
                                                             }
@@ -5616,7 +5616,7 @@ ShallowWrapper {
                                                             }
                                                             subtitle={
                                                                                           <NumericText
-                                                                                                                        type="currency"
+                                                                                                                        type="fiat"
                                                                                                                         value="0"
                                                                                           />
                                                             }
@@ -5682,7 +5682,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                                 <NumericText
-                                                                                                type="currency"
+                                                                                                type="fiat"
                                                                                                 value="0"
                                                                 />
                                 }
@@ -5705,7 +5705,7 @@ ShallowWrapper {
                                   ETH
 </SelectableText>,
                                 "subtitle": <NumericText
-                                  type="currency"
+                                  type="fiat"
                                   value="0"
 />,
                               },
@@ -5771,7 +5771,7 @@ ShallowWrapper {
                                 }
                                 subtitle={
                                                                 <NumericText
-                                                                                                type="currency"
+                                                                                                type="fiat"
                                                                                                 value="0"
                                                                 />
                                 }
@@ -5794,7 +5794,7 @@ ShallowWrapper {
                                   ETH
 </SelectableText>,
                                 "subtitle": <NumericText
-                                  type="currency"
+                                  type="fiat"
                                   value="0"
 />,
                               },

--- a/src/containers/NahmiiWithdraw/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/NahmiiWithdraw/tests/__snapshots__/index.test.js.snap
@@ -488,6 +488,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -730,6 +731,7 @@ ShallowWrapper {
                                                   intl={
                                                             Object {
                                                                       "formatMessage": [Function],
+                                                                      "formatNumber": [Function],
                                                                     }
                                                   }
                                                   onChange={[Function]}
@@ -771,6 +773,7 @@ ShallowWrapper {
                                                             main={
                                                                       <SelectableText>
                                                                                 <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0"
                                                                                 />
                                                                                  
@@ -805,6 +808,7 @@ ShallowWrapper {
                                                             main={
                                                                       <SelectableText>
                                                                                 <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.06"
                                                                                 />
                                                                                  
@@ -838,6 +842,7 @@ ShallowWrapper {
                                                             main={
                                                                       <SelectableText>
                                                                                 <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.198937"
                                                                                 />
                                                                                  
@@ -871,6 +876,7 @@ ShallowWrapper {
                                                             main={
                                                                       <SelectableText>
                                                                                 <NumericText
+                                                                                          maxDecimalPlaces={18}
                                                                                           value="0.138937"
                                                                                 />
                                                                                  
@@ -905,6 +911,7 @@ ShallowWrapper {
                                                                       main={
                                                                                 <SelectableText>
                                                                                           <NumericText
+                                                                                                    maxDecimalPlaces={18}
                                                                                                     value="0"
                                                                                           />
                                                                                            
@@ -938,6 +945,7 @@ ShallowWrapper {
                                                                       main={
                                                                                 <SelectableText>
                                                                                           <NumericText
+                                                                                                    maxDecimalPlaces={18}
                                                                                                     value="0"
                                                                                           />
                                                                                            
@@ -1082,6 +1090,7 @@ ShallowWrapper {
                                                 intl={
                                                             Object {
                                                                         "formatMessage": [Function],
+                                                                        "formatNumber": [Function],
                                                                       }
                                                 }
                                                 onChange={[Function]}
@@ -1123,6 +1132,7 @@ ShallowWrapper {
                                                             main={
                                                                         <SelectableText>
                                                                                     <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0"
                                                                                     />
                                                                                      
@@ -1157,6 +1167,7 @@ ShallowWrapper {
                                                             main={
                                                                         <SelectableText>
                                                                                     <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.06"
                                                                                     />
                                                                                      
@@ -1190,6 +1201,7 @@ ShallowWrapper {
                                                             main={
                                                                         <SelectableText>
                                                                                     <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.198937"
                                                                                     />
                                                                                      
@@ -1223,6 +1235,7 @@ ShallowWrapper {
                                                             main={
                                                                         <SelectableText>
                                                                                     <NumericText
+                                                                                                maxDecimalPlaces={18}
                                                                                                 value="0.138937"
                                                                                     />
                                                                                      
@@ -1257,6 +1270,7 @@ ShallowWrapper {
                                                                         main={
                                                                                     <SelectableText>
                                                                                                 <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0"
                                                                                                 />
                                                                                                  
@@ -1290,6 +1304,7 @@ ShallowWrapper {
                                                                         main={
                                                                                     <SelectableText>
                                                                                                 <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0"
                                                                                                 />
                                                                                                  
@@ -1414,6 +1429,7 @@ ShallowWrapper {
                                                 intl={
                                                                 Object {
                                                                                 "formatMessage": [Function],
+                                                                                "formatNumber": [Function],
                                                                               }
                                                 }
                                                 onChange={[Function]}
@@ -1455,6 +1471,7 @@ ShallowWrapper {
                                                                 main={
                                                                                 <SelectableText>
                                                                                                 <NumericText
+                                                                                                                maxDecimalPlaces={18}
                                                                                                                 value="0"
                                                                                                 />
                                                                                                  
@@ -1489,6 +1506,7 @@ ShallowWrapper {
                                                                 main={
                                                                                 <SelectableText>
                                                                                                 <NumericText
+                                                                                                                maxDecimalPlaces={18}
                                                                                                                 value="0.06"
                                                                                                 />
                                                                                                  
@@ -1522,6 +1540,7 @@ ShallowWrapper {
                                                                 main={
                                                                                 <SelectableText>
                                                                                                 <NumericText
+                                                                                                                maxDecimalPlaces={18}
                                                                                                                 value="0.198937"
                                                                                                 />
                                                                                                  
@@ -1555,6 +1574,7 @@ ShallowWrapper {
                                                                 main={
                                                                                 <SelectableText>
                                                                                                 <NumericText
+                                                                                                                maxDecimalPlaces={18}
                                                                                                                 value="0.138937"
                                                                                                 />
                                                                                                  
@@ -1589,6 +1609,7 @@ ShallowWrapper {
                                                                                 main={
                                                                                                 <SelectableText>
                                                                                                                 <NumericText
+                                                                                                                                maxDecimalPlaces={18}
                                                                                                                                 value="0"
                                                                                                                 />
                                                                                                                  
@@ -1622,6 +1643,7 @@ ShallowWrapper {
                                                                                 main={
                                                                                                 <SelectableText>
                                                                                                                 <NumericText
+                                                                                                                                maxDecimalPlaces={18}
                                                                                                                                 value="0"
                                                                                                                 />
                                                                                                                  
@@ -1740,6 +1762,7 @@ ShallowWrapper {
                                     intl={
                                                       Object {
                                                                         "formatMessage": [Function],
+                                                                        "formatNumber": [Function],
                                                                       }
                                     }
                                     onChange={[Function]}
@@ -1828,6 +1851,7 @@ ShallowWrapper {
                       intl={
                                             Object {
                                                                   "formatMessage": [Function],
+                                                                  "formatNumber": [Function],
                                                                 }
                       }
                       onChange={[Function]}
@@ -2000,6 +2024,7 @@ ShallowWrapper {
                       "gasStatistics": undefined,
                       "intl": Object {
                         "formatMessage": [Function],
+                        "formatNumber": [Function],
                       },
                       "onChange": [Function],
                     },
@@ -2052,6 +2077,7 @@ ShallowWrapper {
                                                             main={
                                                                                 <SelectableText>
                                                                                                     <NumericText
+                                                                                                                        maxDecimalPlaces={18}
                                                                                                                         value="0"
                                                                                                     />
                                                                                                      
@@ -2086,6 +2112,7 @@ ShallowWrapper {
                                                             main={
                                                                                 <SelectableText>
                                                                                                     <NumericText
+                                                                                                                        maxDecimalPlaces={18}
                                                                                                                         value="0.06"
                                                                                                     />
                                                                                                      
@@ -2119,6 +2146,7 @@ ShallowWrapper {
                                                             main={
                                                                                 <SelectableText>
                                                                                                     <NumericText
+                                                                                                                        maxDecimalPlaces={18}
                                                                                                                         value="0.198937"
                                                                                                     />
                                                                                                      
@@ -2152,6 +2180,7 @@ ShallowWrapper {
                                                             main={
                                                                                 <SelectableText>
                                                                                                     <NumericText
+                                                                                                                        maxDecimalPlaces={18}
                                                                                                                         value="0.138937"
                                                                                                     />
                                                                                                      
@@ -2186,6 +2215,7 @@ ShallowWrapper {
                                                                                 main={
                                                                                                     <SelectableText>
                                                                                                                         <NumericText
+                                                                                                                                            maxDecimalPlaces={18}
                                                                                                                                             value="0"
                                                                                                                         />
                                                                                                                          
@@ -2219,6 +2249,7 @@ ShallowWrapper {
                                                                                 main={
                                                                                                     <SelectableText>
                                                                                                                         <NumericText
+                                                                                                                                            maxDecimalPlaces={18}
                                                                                                                                             value="0"
                                                                                                                         />
                                                                                                                          
@@ -2289,6 +2320,7 @@ ShallowWrapper {
                                                 main={
                                                                         <SelectableText>
                                                                                                 <NumericText
+                                                                                                                        maxDecimalPlaces={18}
                                                                                                                         value="0"
                                                                                                 />
                                                                                                  
@@ -2323,6 +2355,7 @@ ShallowWrapper {
                                                 main={
                                                                         <SelectableText>
                                                                                                 <NumericText
+                                                                                                                        maxDecimalPlaces={18}
                                                                                                                         value="0.06"
                                                                                                 />
                                                                                                  
@@ -2356,6 +2389,7 @@ ShallowWrapper {
                                                 main={
                                                                         <SelectableText>
                                                                                                 <NumericText
+                                                                                                                        maxDecimalPlaces={18}
                                                                                                                         value="0.198937"
                                                                                                 />
                                                                                                  
@@ -2389,6 +2423,7 @@ ShallowWrapper {
                                                 main={
                                                                         <SelectableText>
                                                                                                 <NumericText
+                                                                                                                        maxDecimalPlaces={18}
                                                                                                                         value="0.138937"
                                                                                                 />
                                                                                                  
@@ -2423,6 +2458,7 @@ ShallowWrapper {
                                                                         main={
                                                                                                 <SelectableText>
                                                                                                                         <NumericText
+                                                                                                                                                maxDecimalPlaces={18}
                                                                                                                                                 value="0"
                                                                                                                         />
                                                                                                                          
@@ -2456,6 +2492,7 @@ ShallowWrapper {
                                                                         main={
                                                                                                 <SelectableText>
                                                                                                                         <NumericText
+                                                                                                                                                maxDecimalPlaces={18}
                                                                                                                                                 value="0"
                                                                                                                         />
                                                                                                                          
@@ -2548,6 +2585,7 @@ ShallowWrapper {
                           main={
                                                     <SelectableText>
                                                                               <NumericText
+                                                                                                        maxDecimalPlaces={18}
                                                                                                         value="0"
                                                                               />
                                                                                
@@ -2571,6 +2609,7 @@ ShallowWrapper {
                         "props": Object {
                           "main": <SelectableText>
                             <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0"
                             />
                              
@@ -2642,6 +2681,7 @@ ShallowWrapper {
                           main={
                                                     <SelectableText>
                                                                               <NumericText
+                                                                                                        maxDecimalPlaces={18}
                                                                                                         value="0.06"
                                                                               />
                                                                                
@@ -2665,6 +2705,7 @@ ShallowWrapper {
                         "props": Object {
                           "main": <SelectableText>
                             <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.06"
                             />
                              
@@ -2728,6 +2769,7 @@ ShallowWrapper {
                           main={
                                                     <SelectableText>
                                                                               <NumericText
+                                                                                                        maxDecimalPlaces={18}
                                                                                                         value="0.198937"
                                                                               />
                                                                                
@@ -2752,6 +2794,7 @@ ShallowWrapper {
                           "className": "base-layer-eth-balance-before",
                           "main": <SelectableText>
                             <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.198937"
                             />
                              
@@ -2815,6 +2858,7 @@ ShallowWrapper {
                           main={
                                                     <SelectableText>
                                                                               <NumericText
+                                                                                                        maxDecimalPlaces={18}
                                                                                                         value="0.138937"
                                                                               />
                                                                                
@@ -2839,6 +2883,7 @@ ShallowWrapper {
                           "className": "base-layer-eth-balance-after",
                           "main": <SelectableText>
                             <NumericText
+                                                        maxDecimalPlaces={18}
                                                         value="0.138937"
                             />
                              
@@ -2880,6 +2925,7 @@ ShallowWrapper {
                                                         main={
                                                                                     <SelectableText>
                                                                                                                 <NumericText
+                                                                                                                                            maxDecimalPlaces={18}
                                                                                                                                             value="0"
                                                                                                                 />
                                                                                                                  
@@ -2913,6 +2959,7 @@ ShallowWrapper {
                                                         main={
                                                                                     <SelectableText>
                                                                                                                 <NumericText
+                                                                                                                                            maxDecimalPlaces={18}
                                                                                                                                             value="0"
                                                                                                                 />
                                                                                                                  
@@ -2978,6 +3025,7 @@ ShallowWrapper {
                               main={
                                                             <SelectableText>
                                                                                           <NumericText
+                                                                                                                        maxDecimalPlaces={18}
                                                                                                                         value="0"
                                                                                           />
                                                                                            
@@ -3002,6 +3050,7 @@ ShallowWrapper {
                               "className": "staged-balance-before",
                               "main": <SelectableText>
                                 <NumericText
+                                                                maxDecimalPlaces={18}
                                                                 value="0"
                                 />
                                  
@@ -3065,6 +3114,7 @@ ShallowWrapper {
                               main={
                                                             <SelectableText>
                                                                                           <NumericText
+                                                                                                                        maxDecimalPlaces={18}
                                                                                                                         value="0"
                                                                                           />
                                                                                            
@@ -3089,6 +3139,7 @@ ShallowWrapper {
                               "className": "staged-balance-after",
                               "main": <SelectableText>
                                 <NumericText
+                                                                maxDecimalPlaces={18}
                                                                 value="0"
                                 />
                                  
@@ -3328,6 +3379,7 @@ ShallowWrapper {
                                                             intl={
                                                                         Object {
                                                                                     "formatMessage": [Function],
+                                                                                    "formatNumber": [Function],
                                                                                   }
                                                             }
                                                             onChange={[Function]}
@@ -3369,6 +3421,7 @@ ShallowWrapper {
                                                                         main={
                                                                                     <SelectableText>
                                                                                                 <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0"
                                                                                                 />
                                                                                                  
@@ -3403,6 +3456,7 @@ ShallowWrapper {
                                                                         main={
                                                                                     <SelectableText>
                                                                                                 <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.06"
                                                                                                 />
                                                                                                  
@@ -3436,6 +3490,7 @@ ShallowWrapper {
                                                                         main={
                                                                                     <SelectableText>
                                                                                                 <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.198937"
                                                                                                 />
                                                                                                  
@@ -3469,6 +3524,7 @@ ShallowWrapper {
                                                                         main={
                                                                                     <SelectableText>
                                                                                                 <NumericText
+                                                                                                            maxDecimalPlaces={18}
                                                                                                             value="0.138937"
                                                                                                 />
                                                                                                  
@@ -3503,6 +3559,7 @@ ShallowWrapper {
                                                                                     main={
                                                                                                 <SelectableText>
                                                                                                             <NumericText
+                                                                                                                        maxDecimalPlaces={18}
                                                                                                                         value="0"
                                                                                                             />
                                                                                                              
@@ -3536,6 +3593,7 @@ ShallowWrapper {
                                                                                     main={
                                                                                                 <SelectableText>
                                                                                                             <NumericText
+                                                                                                                        maxDecimalPlaces={18}
                                                                                                                         value="0"
                                                                                                             />
                                                                                                              
@@ -3680,6 +3738,7 @@ ShallowWrapper {
                                                         intl={
                                                                       Object {
                                                                                     "formatMessage": [Function],
+                                                                                    "formatNumber": [Function],
                                                                                   }
                                                         }
                                                         onChange={[Function]}
@@ -3721,6 +3780,7 @@ ShallowWrapper {
                                                                       main={
                                                                                     <SelectableText>
                                                                                                   <NumericText
+                                                                                                                maxDecimalPlaces={18}
                                                                                                                 value="0"
                                                                                                   />
                                                                                                    
@@ -3755,6 +3815,7 @@ ShallowWrapper {
                                                                       main={
                                                                                     <SelectableText>
                                                                                                   <NumericText
+                                                                                                                maxDecimalPlaces={18}
                                                                                                                 value="0.06"
                                                                                                   />
                                                                                                    
@@ -3788,6 +3849,7 @@ ShallowWrapper {
                                                                       main={
                                                                                     <SelectableText>
                                                                                                   <NumericText
+                                                                                                                maxDecimalPlaces={18}
                                                                                                                 value="0.198937"
                                                                                                   />
                                                                                                    
@@ -3821,6 +3883,7 @@ ShallowWrapper {
                                                                       main={
                                                                                     <SelectableText>
                                                                                                   <NumericText
+                                                                                                                maxDecimalPlaces={18}
                                                                                                                 value="0.138937"
                                                                                                   />
                                                                                                    
@@ -3855,6 +3918,7 @@ ShallowWrapper {
                                                                                     main={
                                                                                                   <SelectableText>
                                                                                                                 <NumericText
+                                                                                                                              maxDecimalPlaces={18}
                                                                                                                               value="0"
                                                                                                                 />
                                                                                                                  
@@ -3888,6 +3952,7 @@ ShallowWrapper {
                                                                                     main={
                                                                                                   <SelectableText>
                                                                                                                 <NumericText
+                                                                                                                              maxDecimalPlaces={18}
                                                                                                                               value="0"
                                                                                                                 />
                                                                                                                  
@@ -4012,6 +4077,7 @@ ShallowWrapper {
                                                       intl={
                                                                         Object {
                                                                                           "formatMessage": [Function],
+                                                                                          "formatNumber": [Function],
                                                                                         }
                                                       }
                                                       onChange={[Function]}
@@ -4053,6 +4119,7 @@ ShallowWrapper {
                                                                         main={
                                                                                           <SelectableText>
                                                                                                             <NumericText
+                                                                                                                              maxDecimalPlaces={18}
                                                                                                                               value="0"
                                                                                                             />
                                                                                                              
@@ -4087,6 +4154,7 @@ ShallowWrapper {
                                                                         main={
                                                                                           <SelectableText>
                                                                                                             <NumericText
+                                                                                                                              maxDecimalPlaces={18}
                                                                                                                               value="0.06"
                                                                                                             />
                                                                                                              
@@ -4120,6 +4188,7 @@ ShallowWrapper {
                                                                         main={
                                                                                           <SelectableText>
                                                                                                             <NumericText
+                                                                                                                              maxDecimalPlaces={18}
                                                                                                                               value="0.198937"
                                                                                                             />
                                                                                                              
@@ -4153,6 +4222,7 @@ ShallowWrapper {
                                                                         main={
                                                                                           <SelectableText>
                                                                                                             <NumericText
+                                                                                                                              maxDecimalPlaces={18}
                                                                                                                               value="0.138937"
                                                                                                             />
                                                                                                              
@@ -4187,6 +4257,7 @@ ShallowWrapper {
                                                                                           main={
                                                                                                             <SelectableText>
                                                                                                                               <NumericText
+                                                                                                                                                maxDecimalPlaces={18}
                                                                                                                                                 value="0"
                                                                                                                               />
                                                                                                                                
@@ -4220,6 +4291,7 @@ ShallowWrapper {
                                                                                           main={
                                                                                                             <SelectableText>
                                                                                                                               <NumericText
+                                                                                                                                                maxDecimalPlaces={18}
                                                                                                                                                 value="0"
                                                                                                                               />
                                                                                                                                
@@ -4338,6 +4410,7 @@ ShallowWrapper {
                                         intl={
                                                             Object {
                                                                                 "formatMessage": [Function],
+                                                                                "formatNumber": [Function],
                                                                               }
                                         }
                                         onChange={[Function]}
@@ -4426,6 +4499,7 @@ ShallowWrapper {
                         intl={
                                                 Object {
                                                                         "formatMessage": [Function],
+                                                                        "formatNumber": [Function],
                                                                       }
                         }
                         onChange={[Function]}
@@ -4598,6 +4672,7 @@ ShallowWrapper {
                         "gasStatistics": undefined,
                         "intl": Object {
                           "formatMessage": [Function],
+                          "formatNumber": [Function],
                         },
                         "onChange": [Function],
                       },
@@ -4650,6 +4725,7 @@ ShallowWrapper {
                                                                   main={
                                                                                         <SelectableText>
                                                                                                               <NumericText
+                                                                                                                                    maxDecimalPlaces={18}
                                                                                                                                     value="0"
                                                                                                               />
                                                                                                                
@@ -4684,6 +4760,7 @@ ShallowWrapper {
                                                                   main={
                                                                                         <SelectableText>
                                                                                                               <NumericText
+                                                                                                                                    maxDecimalPlaces={18}
                                                                                                                                     value="0.06"
                                                                                                               />
                                                                                                                
@@ -4717,6 +4794,7 @@ ShallowWrapper {
                                                                   main={
                                                                                         <SelectableText>
                                                                                                               <NumericText
+                                                                                                                                    maxDecimalPlaces={18}
                                                                                                                                     value="0.198937"
                                                                                                               />
                                                                                                                
@@ -4750,6 +4828,7 @@ ShallowWrapper {
                                                                   main={
                                                                                         <SelectableText>
                                                                                                               <NumericText
+                                                                                                                                    maxDecimalPlaces={18}
                                                                                                                                     value="0.138937"
                                                                                                               />
                                                                                                                
@@ -4784,6 +4863,7 @@ ShallowWrapper {
                                                                                         main={
                                                                                                               <SelectableText>
                                                                                                                                     <NumericText
+                                                                                                                                                          maxDecimalPlaces={18}
                                                                                                                                                           value="0"
                                                                                                                                     />
                                                                                                                                      
@@ -4817,6 +4897,7 @@ ShallowWrapper {
                                                                                         main={
                                                                                                               <SelectableText>
                                                                                                                                     <NumericText
+                                                                                                                                                          maxDecimalPlaces={18}
                                                                                                                                                           value="0"
                                                                                                                                     />
                                                                                                                                      
@@ -4887,6 +4968,7 @@ ShallowWrapper {
                                                     main={
                                                                               <SelectableText>
                                                                                                         <NumericText
+                                                                                                                                  maxDecimalPlaces={18}
                                                                                                                                   value="0"
                                                                                                         />
                                                                                                          
@@ -4921,6 +5003,7 @@ ShallowWrapper {
                                                     main={
                                                                               <SelectableText>
                                                                                                         <NumericText
+                                                                                                                                  maxDecimalPlaces={18}
                                                                                                                                   value="0.06"
                                                                                                         />
                                                                                                          
@@ -4954,6 +5037,7 @@ ShallowWrapper {
                                                     main={
                                                                               <SelectableText>
                                                                                                         <NumericText
+                                                                                                                                  maxDecimalPlaces={18}
                                                                                                                                   value="0.198937"
                                                                                                         />
                                                                                                          
@@ -4987,6 +5071,7 @@ ShallowWrapper {
                                                     main={
                                                                               <SelectableText>
                                                                                                         <NumericText
+                                                                                                                                  maxDecimalPlaces={18}
                                                                                                                                   value="0.138937"
                                                                                                         />
                                                                                                          
@@ -5021,6 +5106,7 @@ ShallowWrapper {
                                                                               main={
                                                                                                         <SelectableText>
                                                                                                                                   <NumericText
+                                                                                                                                                            maxDecimalPlaces={18}
                                                                                                                                                             value="0"
                                                                                                                                   />
                                                                                                                                    
@@ -5054,6 +5140,7 @@ ShallowWrapper {
                                                                               main={
                                                                                                         <SelectableText>
                                                                                                                                   <NumericText
+                                                                                                                                                            maxDecimalPlaces={18}
                                                                                                                                                             value="0"
                                                                                                                                   />
                                                                                                                                    
@@ -5146,6 +5233,7 @@ ShallowWrapper {
                             main={
                                                         <SelectableText>
                                                                                     <NumericText
+                                                                                                                maxDecimalPlaces={18}
                                                                                                                 value="0"
                                                                                     />
                                                                                      
@@ -5169,6 +5257,7 @@ ShallowWrapper {
                           "props": Object {
                             "main": <SelectableText>
                               <NumericText
+                                                            maxDecimalPlaces={18}
                                                             value="0"
                               />
                                
@@ -5240,6 +5329,7 @@ ShallowWrapper {
                             main={
                                                         <SelectableText>
                                                                                     <NumericText
+                                                                                                                maxDecimalPlaces={18}
                                                                                                                 value="0.06"
                                                                                     />
                                                                                      
@@ -5263,6 +5353,7 @@ ShallowWrapper {
                           "props": Object {
                             "main": <SelectableText>
                               <NumericText
+                                                            maxDecimalPlaces={18}
                                                             value="0.06"
                               />
                                
@@ -5326,6 +5417,7 @@ ShallowWrapper {
                             main={
                                                         <SelectableText>
                                                                                     <NumericText
+                                                                                                                maxDecimalPlaces={18}
                                                                                                                 value="0.198937"
                                                                                     />
                                                                                      
@@ -5350,6 +5442,7 @@ ShallowWrapper {
                             "className": "base-layer-eth-balance-before",
                             "main": <SelectableText>
                               <NumericText
+                                                            maxDecimalPlaces={18}
                                                             value="0.198937"
                               />
                                
@@ -5413,6 +5506,7 @@ ShallowWrapper {
                             main={
                                                         <SelectableText>
                                                                                     <NumericText
+                                                                                                                maxDecimalPlaces={18}
                                                                                                                 value="0.138937"
                                                                                     />
                                                                                      
@@ -5437,6 +5531,7 @@ ShallowWrapper {
                             "className": "base-layer-eth-balance-after",
                             "main": <SelectableText>
                               <NumericText
+                                                            maxDecimalPlaces={18}
                                                             value="0.138937"
                               />
                                
@@ -5478,6 +5573,7 @@ ShallowWrapper {
                                                             main={
                                                                                           <SelectableText>
                                                                                                                         <NumericText
+                                                                                                                                                      maxDecimalPlaces={18}
                                                                                                                                                       value="0"
                                                                                                                         />
                                                                                                                          
@@ -5511,6 +5607,7 @@ ShallowWrapper {
                                                             main={
                                                                                           <SelectableText>
                                                                                                                         <NumericText
+                                                                                                                                                      maxDecimalPlaces={18}
                                                                                                                                                       value="0"
                                                                                                                         />
                                                                                                                          
@@ -5576,6 +5673,7 @@ ShallowWrapper {
                                 main={
                                                                 <SelectableText>
                                                                                                 <NumericText
+                                                                                                                                maxDecimalPlaces={18}
                                                                                                                                 value="0"
                                                                                                 />
                                                                                                  
@@ -5600,6 +5698,7 @@ ShallowWrapper {
                                 "className": "staged-balance-before",
                                 "main": <SelectableText>
                                   <NumericText
+                                                                    maxDecimalPlaces={18}
                                                                     value="0"
                                   />
                                    
@@ -5663,6 +5762,7 @@ ShallowWrapper {
                                 main={
                                                                 <SelectableText>
                                                                                                 <NumericText
+                                                                                                                                maxDecimalPlaces={18}
                                                                                                                                 value="0"
                                                                                                 />
                                                                                                  
@@ -5687,6 +5787,7 @@ ShallowWrapper {
                                 "className": "staged-balance-after",
                                 "main": <SelectableText>
                                   <NumericText
+                                                                    maxDecimalPlaces={18}
                                                                     value="0"
                                   />
                                    

--- a/src/containers/Settings/BatchImportSteps/DecryptForm/index.js
+++ b/src/containers/Settings/BatchImportSteps/DecryptForm/index.js
@@ -68,7 +68,7 @@ export class DecryptForm extends React.Component {
                   required: true,
                 },
               ],
-            })(<ModalFormInput />)}
+            })(<ModalFormInput type="password" />)}
           </ModalFormItem>
           <ModalFormItem
             label={

--- a/src/containers/Settings/ExportModal/index.js
+++ b/src/containers/Settings/ExportModal/index.js
@@ -21,6 +21,9 @@ export class ExportModal extends React.Component {
     this.state = { filePath: null, password: null };
     this.handleExport = this.handleExport.bind(this);
     this.handleSetFilePath = this.handleSetFilePath.bind(this);
+    this.handleConfirmBlur = this.handleConfirmBlur.bind(this);
+    this.compareToFirstPassword = this.compareToFirstPassword.bind(this);
+    this.validateToNextPassword = this.validateToNextPassword.bind(this);
   }
 
   handleSetFilePath() {
@@ -45,6 +48,30 @@ export class ExportModal extends React.Component {
     });
   }
 
+  handleConfirmBlur(e) {
+    const value = e.target.value;
+    this.setState({
+      confirmPasswordsMatch: this.state.confirmPasswordsMatch || !!value,
+    });
+  }
+
+  compareToFirstPassword(rule, value, callback) {
+    const form = this.props.form;
+    const { formatMessage } = this.props.intl;
+    if (value && value !== form.getFieldValue('password')) {
+      callback(formatMessage({ id: 'password_notmatch' }));
+    } else {
+      callback();
+    }
+  }
+
+  validateToNextPassword(rule, value, callback) {
+    const form = this.props.form;
+    if (value && this.state.confirmPasswordsMatch) {
+      form.validateFields(['confirm'], { force: true });
+    }
+    callback();
+  }
 
   render() {
     const { getFieldDecorator } = this.props.form;
@@ -68,7 +95,28 @@ export class ExportModal extends React.Component {
                   required: true,
                 },
               ],
-            })(<ModalFormInput />)}
+            })(<ModalFormInput type="password" />)}
+          </ModalFormItem>
+          <ModalFormItem
+            colon={false}
+            label={<ModalFormLabel>{formatMessage({ id: 'repeat_password' })}</ModalFormLabel>}
+          >
+            {getFieldDecorator('confirm', {
+              rules: [
+                {
+                  required: true,
+                  message: formatMessage({ id: 'confirm_password' }),
+                },
+                {
+                  validator: this.compareToFirstPassword,
+                },
+              ],
+            })(
+              <ModalFormInput
+                type="password"
+                onBlur={this.handleConfirmBlur}
+              />
+            )}
           </ModalFormItem>
           <ModalFormItem
             label={

--- a/src/containers/Settings/ExportModal/index.js
+++ b/src/containers/Settings/ExportModal/index.js
@@ -94,8 +94,15 @@ export class ExportModal extends React.Component {
                   message: formatMessage({ id: 'enter_backup_encrypt_password' }),
                   required: true,
                 },
+                {
+                  validator: this.validateToNextPassword,
+                },
               ],
-            })(<ModalFormInput type="password" />)}
+            })(
+              <ModalFormInput
+                type="password"
+              />
+            )}
           </ModalFormItem>
           <ModalFormItem
             colon={false}

--- a/src/containers/Settings/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/Settings/tests/__snapshots__/index.test.js.snap
@@ -116,6 +116,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     locale="en"

--- a/src/containers/WalletDetails/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/WalletDetails/tests/__snapshots__/index.test.js.snap
@@ -382,6 +382,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerInfo={

--- a/src/containers/WalletHoc/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/WalletHoc/tests/__snapshots__/index.test.js.snap
@@ -383,6 +383,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     loading={
@@ -784,6 +785,7 @@ ShallowWrapper {
           intl={
                     Object {
                               "formatMessage": [Function],
+                              "formatNumber": [Function],
                             }
           }
           loading={
@@ -1211,6 +1213,7 @@ ShallowWrapper {
           "hideDecryptWalletModal": [Function],
           "intl": Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           },
           "loading": Immutable.Map {
             decryptingWallet: false,
@@ -1701,6 +1704,7 @@ ShallowWrapper {
             intl={
                         Object {
                                     "formatMessage": [Function],
+                                    "formatNumber": [Function],
                                   }
             }
             loading={
@@ -2128,6 +2132,7 @@ ShallowWrapper {
             "hideDecryptWalletModal": [Function],
             "intl": Object {
               "formatMessage": [Function],
+              "formatNumber": [Function],
             },
             "loading": Immutable.Map {
               decryptingWallet: false,
@@ -2626,6 +2631,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     loading={
@@ -3027,6 +3033,7 @@ ShallowWrapper {
           intl={
                     Object {
                               "formatMessage": [Function],
+                              "formatNumber": [Function],
                             }
           }
           loading={
@@ -3451,6 +3458,7 @@ ShallowWrapper {
           "hideDecryptWalletModal": [Function],
           "intl": Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           },
           "loading": Immutable.Map {
             decryptingWallet: true,
@@ -3936,6 +3944,7 @@ ShallowWrapper {
             intl={
                         Object {
                                     "formatMessage": [Function],
+                                    "formatNumber": [Function],
                                   }
             }
             loading={
@@ -4360,6 +4369,7 @@ ShallowWrapper {
             "hideDecryptWalletModal": [Function],
             "intl": Object {
               "formatMessage": [Function],
+              "formatNumber": [Function],
             },
             "loading": Immutable.Map {
               decryptingWallet: true,

--- a/src/containers/WalletsOverview/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/WalletsOverview/tests/__snapshots__/index.test.js.snap
@@ -16,6 +16,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -6496,6 +6497,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -12976,6 +12978,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -15200,6 +15203,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -17424,6 +17428,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -25612,6 +25617,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={
@@ -33206,6 +33212,7 @@ ShallowWrapper {
     intl={
         Object {
             "formatMessage": [Function],
+            "formatNumber": [Function],
           }
     }
     ledgerNanoSInfo={

--- a/src/jest/__mocks__/react-intl.js
+++ b/src/jest/__mocks__/react-intl.js
@@ -2,6 +2,7 @@ const Intl = jest.genMockFromModule('react-intl');
 
 Intl.intl = {
   formatMessage: ({ id }, params) => params ? `${id} ${JSON.stringify(params)}` : id,
+  formatNumber: (value, params) => params ? `${value} ${JSON.stringify(params)}` : value,
 };
 
 Intl.injectIntl = (Node) => Node;

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,9 +295,9 @@
   integrity sha512-eajkMXG812/w3w4a1OcBlaTwsFPO5F7fJ/amy+tieQxEMWBlbV1JGSjkFM+zkHNf81Cad+dfIRA+IBkvmvdAeA==
 
 "@types/node@^10.12.18":
-  version "10.14.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.7.tgz#1854f0a9aa8d2cd6818d607b3d091346c6730362"
-  integrity sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A==
+  version "10.14.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.8.tgz#fe444203ecef1162348cd6deb76c62477b2cc6e9"
+  integrity sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==
 
 "@types/node@^10.3.2":
   version "10.12.12"
@@ -11053,10 +11053,10 @@ mime@^2.0.3, mime@^2.1.0, mime@^2.3.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
   integrity sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==
 
-mime@^2.4.2:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.3.tgz#229687331e86f68924e6cb59e1cdd937f18275fe"
-  integrity sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw==
+mime@^2.4.3:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
+  integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -14290,7 +14290,7 @@ readable-stream@^3.0.6:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@^3.3.0:
+readable-stream@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
   integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
@@ -15241,7 +15241,7 @@ semver@^4.0.3:
   resolved "http://registry.npmjs.org/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
   integrity sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=
 
-semver@^6.0.0:
+semver@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.1.tgz#53f53da9b30b2103cd4f15eab3a18ecbcb210c9b"
   integrity sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==
@@ -16263,9 +16263,9 @@ sumchecker@^2.0.2:
     debug "^2.2.0"
 
 superagent@^5.0.2:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-5.0.5.tgz#53d0f578c4db0aab1a849b647af01b9750f8a2e7"
-  integrity sha512-5fnihpNqJfDJHxeIkqlXKFDOW5t4WUFV8Ba1erxdWT0RySqjgAW6Hska0xNYEpAfaoMzubn77GROm/XlkssOoQ==
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-5.0.6.tgz#78cb26a2742cfadc7aa422c329f23bbd61f08121"
+  integrity sha512-Rs1F18i4/o3C5N1kKAjWRS+uwQma3zz8J+hduC3E6CCE9LMF44ZPInBuvAibpgDoTtj42nkRNuasQ2r2JeMMIw==
   dependencies:
     component-emitter "^1.3.0"
     cookiejar "^2.1.2"
@@ -16273,10 +16273,10 @@ superagent@^5.0.2:
     form-data "^2.3.3"
     formidable "^1.2.1"
     methods "^1.1.2"
-    mime "^2.4.2"
+    mime "^2.4.3"
     qs "^6.7.0"
-    readable-stream "^3.3.0"
-    semver "^6.0.0"
+    readable-stream "^3.4.0"
+    semver "^6.1.1"
 
 supports-color@^0.2.0:
   version "0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11293,10 +11293,10 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-nahmii-contract-abstractions-ropsten@~1.5.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/nahmii-contract-abstractions-ropsten/-/nahmii-contract-abstractions-ropsten-1.5.3.tgz#ff5899295977fd12fa39a5bd3ee9dd5e838c5d5c"
-  integrity sha512-kTbopi8ZnsyXeVO68IDcoxkpoM0E1aRcmRcQbABPbFYURDxO4OMK9HDZdDUwxE0n9RwvaULoMhJltSlHxR0odg==
+nahmii-contract-abstractions-ropsten@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/nahmii-contract-abstractions-ropsten/-/nahmii-contract-abstractions-ropsten-2.0.0.tgz#b534eada104326e6a554e5154b5739c0c770f901"
+  integrity sha512-0JO5Y7lwQeDAGxVvnKi8gfuH+WsNK/j7LeXnjtD2fEvjbTPrUAHxGOpZi4+hyYLoZQ/jW4lA/2TOCmha+ixQOw==
   dependencies:
     glob "^7.1.4"
 
@@ -11314,16 +11314,16 @@ nahmii-ethereum-address@^2.0.0:
   dependencies:
     bson "^3.0.2"
 
-nahmii-sdk@2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/nahmii-sdk/-/nahmii-sdk-2.2.3.tgz#f83f303202e9bc083f99d10361cc3e1aaf7bea27"
-  integrity sha512-3hgPxFOASKRTZQSSTJYVxYPvF9uL9xdEMV53Q2p9dHa3W/nkzKdCgV+3mh2uJ/mC5k1Ws2JW+k//Gmr+1kYw2w==
+nahmii-sdk@2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/nahmii-sdk/-/nahmii-sdk-2.2.5.tgz#45293255b41ff80197887757afdad81aa159ae72"
+  integrity sha512-7Gy+adUu/culgPKZP/707jWczI954hlm+BEk/E/amMNUpsIuvnEdbDQ9yfPVycTgmWcUnWeNh5xB+4EUtaZD8A==
   dependencies:
     ethereumjs-util "^6.1.0"
     keythereum "^1.0.4"
     lodash.get "^4.4.2"
     nahmii-contract-abstractions "1.2.2"
-    nahmii-contract-abstractions-ropsten "~1.5.3"
+    nahmii-contract-abstractions-ropsten "~2.0.0"
     nahmii-ethereum-address "^2.0.0"
     node-yaml "^3.2.0"
     socket.io-client "^2.2.0"


### PR DESCRIPTION
- [x] Support display numbers in an exponential format in order to save space, while indicating it is not a zero number. #759
- [x] Mask the passwords in both batch export and import, and add a repeat password field in the export dialog. #757 
- [ ] Upgrade SDK to wire up with the latest mainnet contracts to support settlements.