### PR TITLE
Add nahmiiActive balances

### DIFF
--- a/src/components/BreakdownList/index.js
+++ b/src/components/BreakdownList/index.js
@@ -77,7 +77,7 @@ class BreakdownList extends React.PureComponent {
       combinedBreakdown,
       baseLayerBreakdown,
       nahmiiAvailableBreakdown,
-      nahmiiCombinedBreakdown,
+      nahmiiActiveBreakdown,
       nahmiiStagedBreakdown,
       nahmiiStagingBreakdown,
       expandedAmount,
@@ -85,7 +85,7 @@ class BreakdownList extends React.PureComponent {
     const { formatMessage } = this.props.intl;
     const combinedBalanceList = generateList(combinedBreakdown, formatMessage, true);
     const baseLayerBalanceList = generateList(baseLayerBreakdown, formatMessage);
-    const nahmiiBalanceList = generateList(nahmiiCombinedBreakdown, formatMessage);
+    const nahmiiBalanceList = generateList(nahmiiActiveBreakdown, formatMessage);
     const nahmiiAvailableBalanceList = generateList(nahmiiAvailableBreakdown, formatMessage);
     const nahmiiStagingBalanceList = generateList(nahmiiStagingBreakdown, formatMessage);
     const nahmiiStagedBalanceList = generateList(nahmiiStagedBreakdown, formatMessage);
@@ -124,7 +124,7 @@ BreakdownList.propTypes = {
   togglePie: PropTypes.func.isRequired,
   expandedAmount: PropTypes.number.isRequired,
   combinedBreakdown: PropTypes.array.isRequired,
-  nahmiiCombinedBreakdown: PropTypes.array.isRequired,
+  nahmiiActiveBreakdown: PropTypes.array.isRequired,
   baseLayerBreakdown: PropTypes.array.isRequired,
   nahmiiAvailableBreakdown: PropTypes.array.isRequired,
   nahmiiStagingBreakdown: PropTypes.array.isRequired,

--- a/src/components/BreakdownPie/index.js
+++ b/src/components/BreakdownPie/index.js
@@ -120,7 +120,7 @@ class Breakdown extends React.Component {
                     combinedBreakdown={combinedBreakdown}
                     baseLayerBreakdown={getBreakdown(totalBalances.get('baseLayer'), supportedAssets)}
                     nahmiiAvailableBreakdown={getBreakdown(totalBalances.get('nahmiiAvailable'), supportedAssets)}
-                    nahmiiCombinedBreakdown={getBreakdown(totalBalances.get('nahmiiCombined'), supportedAssets)}
+                    nahmiiActiveBreakdown={getBreakdown(totalBalances.get('nahmiiActive'), supportedAssets)}
                     nahmiiStagingBreakdown={getBreakdown(totalBalances.get('nahmiiStaging'), supportedAssets)}
                     nahmiiStagedBreakdown={getBreakdown(totalBalances.get('nahmiiStaged'), supportedAssets)}
                   />

--- a/src/components/BreakdownPie/tests/__snapshots__/index.test.js.snap
+++ b/src/components/BreakdownPie/tests/__snapshots__/index.test.js.snap
@@ -87,6 +87,27 @@ ShallowWrapper {
                     usd: "0",
                 },
             },
+            nahmiiActive: Immutable.Map {
+                assets: Immutable.Map {
+                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                        value: Immutable.Map {
+                            usd: "82.4",
+                        },
+                        amount: "0.2",
+                    },
+                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                        value: Immutable.Map {
+                            usd: "0.13",
+                        },
+                        amount: "0.13",
+                    },
+                },
+                loading: false,
+                error: null,
+                total: Immutable.Map {
+                    usd: "82.53",
+                },
+            },
             nahmiiCombined: Immutable.Map {
                 assets: Immutable.Map {
                     0x0000000000000000000000000000000000000000: Immutable.Map {
@@ -330,6 +351,27 @@ ShallowWrapper {
                 error: null,
                 total: Immutable.Map {
                     usd: "0",
+                },
+            },
+            nahmiiActive: Immutable.Map {
+                assets: Immutable.Map {
+                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                        value: Immutable.Map {
+                            usd: "82.4",
+                        },
+                        amount: "0.2",
+                    },
+                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                        value: Immutable.Map {
+                            usd: "0.13",
+                        },
+                        amount: "0.13",
+                    },
+                },
+                loading: false,
+                error: null,
+                total: Immutable.Map {
+                    usd: "82.53",
                 },
             },
             nahmiiCombined: Immutable.Map {
@@ -583,6 +625,15 @@ ShallowWrapper {
                     usd: "0",
                 },
             },
+            nahmiiActive: Immutable.Map {
+                assets: Immutable.Map {
+                },
+                loading: false,
+                error: null,
+                total: Immutable.Map {
+                    usd: "0",
+                },
+            },
             nahmiiCombined: Immutable.Map {
                 assets: Immutable.Map {
                 },
@@ -805,6 +856,15 @@ ShallowWrapper {
                 assets: Immutable.Map {
                 },
                 loading: true,
+                error: null,
+                total: Immutable.Map {
+                    usd: "0",
+                },
+            },
+            nahmiiActive: Immutable.Map {
+                assets: Immutable.Map {
+                },
+                loading: false,
                 error: null,
                 total: Immutable.Map {
                     usd: "0",
@@ -1065,6 +1125,27 @@ ShallowWrapper {
                 error: null,
                 total: Immutable.Map {
                     usd: "0",
+                },
+            },
+            nahmiiActive: Immutable.Map {
+                assets: Immutable.Map {
+                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                        value: Immutable.Map {
+                            usd: "82.4",
+                        },
+                        amount: "0.2",
+                    },
+                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                        value: Immutable.Map {
+                            usd: "0.13",
+                        },
+                        amount: "0.13",
+                    },
+                },
+                loading: false,
+                error: null,
+                total: Immutable.Map {
+                    usd: "82.53",
                 },
             },
             nahmiiCombined: Immutable.Map {

--- a/src/components/TransferForm/tests/__snapshots__/index.test.js.snap
+++ b/src/components/TransferForm/tests/__snapshots__/index.test.js.snap
@@ -248,6 +248,37 @@ ShallowWrapper {
                         usd: "82.53",
                     },
                 },
+                nahmiiActive: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
                 combined: Immutable.Map {
                     loading: false,
                     error: null,
@@ -912,6 +943,37 @@ ShallowWrapper {
                                                                                 usd: "82.53",
                                                                       },
                                                             },
+                                                            nahmiiActive: Immutable.Map {
+                                                                      loading: false,
+                                                                      error: null,
+                                                                      assets: Immutable.List [
+                                                                                Immutable.Map {
+                                                                                          currency: "0x0000000000000000000000000000000000000000",
+                                                                                          balance: "0.2",
+                                                                                          symbol: "ETH",
+                                                                                          value: Immutable.Map {
+                                                                                                    eth: "0.2",
+                                                                                                    btc: "0.002",
+                                                                                                    usd: "82.4",
+                                                                                          },
+                                                                                },
+                                                                                Immutable.Map {
+                                                                                          currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                          balance: "0.13",
+                                                                                          symbol: "BOKKY",
+                                                                                          value: Immutable.Map {
+                                                                                                    eth: "0.013",
+                                                                                                    btc: "0.00013",
+                                                                                                    usd: "0.13",
+                                                                                          },
+                                                                                },
+                                                                      ],
+                                                                      total: Immutable.Map {
+                                                                                eth: "0.213",
+                                                                                btc: "0.00213",
+                                                                                usd: "82.53",
+                                                                      },
+                                                            },
                                                             combined: Immutable.Map {
                                                                       loading: false,
                                                                       error: null,
@@ -1468,6 +1530,37 @@ ShallowWrapper {
                                                                                     },
                                                                       },
                                                                       nahmiiCombined: Immutable.Map {
+                                                                                    loading: false,
+                                                                                    error: null,
+                                                                                    assets: Immutable.List [
+                                                                                                  Immutable.Map {
+                                                                                                                currency: "0x0000000000000000000000000000000000000000",
+                                                                                                                balance: "0.2",
+                                                                                                                symbol: "ETH",
+                                                                                                                value: Immutable.Map {
+                                                                                                                              eth: "0.2",
+                                                                                                                              btc: "0.002",
+                                                                                                                              usd: "82.4",
+                                                                                                                },
+                                                                                                  },
+                                                                                                  Immutable.Map {
+                                                                                                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                                balance: "0.13",
+                                                                                                                symbol: "BOKKY",
+                                                                                                                value: Immutable.Map {
+                                                                                                                              eth: "0.013",
+                                                                                                                              btc: "0.00013",
+                                                                                                                              usd: "0.13",
+                                                                                                                },
+                                                                                                  },
+                                                                                    ],
+                                                                                    total: Immutable.Map {
+                                                                                                  eth: "0.213",
+                                                                                                  btc: "0.00213",
+                                                                                                  usd: "82.53",
+                                                                                    },
+                                                                      },
+                                                                      nahmiiActive: Immutable.Map {
                                                                                     loading: false,
                                                                                     error: null,
                                                                                     assets: Immutable.List [
@@ -2611,6 +2704,37 @@ ShallowWrapper {
                                                                                                 usd: "82.53",
                                                                                 },
                                                                 },
+                                                                nahmiiActive: Immutable.Map {
+                                                                                loading: false,
+                                                                                error: null,
+                                                                                assets: Immutable.List [
+                                                                                                Immutable.Map {
+                                                                                                                currency: "0x0000000000000000000000000000000000000000",
+                                                                                                                balance: "0.2",
+                                                                                                                symbol: "ETH",
+                                                                                                                value: Immutable.Map {
+                                                                                                                                eth: "0.2",
+                                                                                                                                btc: "0.002",
+                                                                                                                                usd: "82.4",
+                                                                                                                },
+                                                                                                },
+                                                                                                Immutable.Map {
+                                                                                                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                                balance: "0.13",
+                                                                                                                symbol: "BOKKY",
+                                                                                                                value: Immutable.Map {
+                                                                                                                                eth: "0.013",
+                                                                                                                                btc: "0.00013",
+                                                                                                                                usd: "0.13",
+                                                                                                                },
+                                                                                                },
+                                                                                ],
+                                                                                total: Immutable.Map {
+                                                                                                eth: "0.213",
+                                                                                                btc: "0.00213",
+                                                                                                usd: "82.53",
+                                                                                },
+                                                                },
                                                                 combined: Immutable.Map {
                                                                                 loading: false,
                                                                                 error: null,
@@ -2900,6 +3024,37 @@ ShallowWrapper {
                                                       },
                                     },
                                     nahmiiCombined: Immutable.Map {
+                                                      loading: false,
+                                                      error: null,
+                                                      assets: Immutable.List [
+                                                                        Immutable.Map {
+                                                                                          currency: "0x0000000000000000000000000000000000000000",
+                                                                                          balance: "0.2",
+                                                                                          symbol: "ETH",
+                                                                                          value: Immutable.Map {
+                                                                                                            eth: "0.2",
+                                                                                                            btc: "0.002",
+                                                                                                            usd: "82.4",
+                                                                                          },
+                                                                        },
+                                                                        Immutable.Map {
+                                                                                          currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                          balance: "0.13",
+                                                                                          symbol: "BOKKY",
+                                                                                          value: Immutable.Map {
+                                                                                                            eth: "0.013",
+                                                                                                            btc: "0.00013",
+                                                                                                            usd: "0.13",
+                                                                                          },
+                                                                        },
+                                                      ],
+                                                      total: Immutable.Map {
+                                                                        eth: "0.213",
+                                                                        btc: "0.00213",
+                                                                        usd: "82.53",
+                                                      },
+                                    },
+                                    nahmiiActive: Immutable.Map {
                                                       loading: false,
                                                       error: null,
                                                       assets: Immutable.List [
@@ -3490,6 +3645,37 @@ ShallowWrapper {
                                                                                                 usd: "82.53",
                                                                                     },
                                                                         },
+                                                                        nahmiiActive: Immutable.Map {
+                                                                                    loading: false,
+                                                                                    error: null,
+                                                                                    assets: Immutable.List [
+                                                                                                Immutable.Map {
+                                                                                                            currency: "0x0000000000000000000000000000000000000000",
+                                                                                                            balance: "0.2",
+                                                                                                            symbol: "ETH",
+                                                                                                            value: Immutable.Map {
+                                                                                                                        eth: "0.2",
+                                                                                                                        btc: "0.002",
+                                                                                                                        usd: "82.4",
+                                                                                                            },
+                                                                                                },
+                                                                                                Immutable.Map {
+                                                                                                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                            balance: "0.13",
+                                                                                                            symbol: "BOKKY",
+                                                                                                            value: Immutable.Map {
+                                                                                                                        eth: "0.013",
+                                                                                                                        btc: "0.00013",
+                                                                                                                        usd: "0.13",
+                                                                                                            },
+                                                                                                },
+                                                                                    ],
+                                                                                    total: Immutable.Map {
+                                                                                                eth: "0.213",
+                                                                                                btc: "0.00213",
+                                                                                                usd: "82.53",
+                                                                                    },
+                                                                        },
                                                                         combined: Immutable.Map {
                                                                                     loading: false,
                                                                                     error: null,
@@ -4046,6 +4232,37 @@ ShallowWrapper {
                                                                                                 },
                                                                                 },
                                                                                 nahmiiCombined: Immutable.Map {
+                                                                                                loading: false,
+                                                                                                error: null,
+                                                                                                assets: Immutable.List [
+                                                                                                                Immutable.Map {
+                                                                                                                                currency: "0x0000000000000000000000000000000000000000",
+                                                                                                                                balance: "0.2",
+                                                                                                                                symbol: "ETH",
+                                                                                                                                value: Immutable.Map {
+                                                                                                                                                eth: "0.2",
+                                                                                                                                                btc: "0.002",
+                                                                                                                                                usd: "82.4",
+                                                                                                                                },
+                                                                                                                },
+                                                                                                                Immutable.Map {
+                                                                                                                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                                                balance: "0.13",
+                                                                                                                                symbol: "BOKKY",
+                                                                                                                                value: Immutable.Map {
+                                                                                                                                                eth: "0.013",
+                                                                                                                                                btc: "0.00013",
+                                                                                                                                                usd: "0.13",
+                                                                                                                                },
+                                                                                                                },
+                                                                                                ],
+                                                                                                total: Immutable.Map {
+                                                                                                                eth: "0.213",
+                                                                                                                btc: "0.00213",
+                                                                                                                usd: "82.53",
+                                                                                                },
+                                                                                },
+                                                                                nahmiiActive: Immutable.Map {
                                                                                                 loading: false,
                                                                                                 error: null,
                                                                                                 assets: Immutable.List [
@@ -5189,6 +5406,37 @@ ShallowWrapper {
                                                                                                             usd: "82.53",
                                                                                           },
                                                                         },
+                                                                        nahmiiActive: Immutable.Map {
+                                                                                          loading: false,
+                                                                                          error: null,
+                                                                                          assets: Immutable.List [
+                                                                                                            Immutable.Map {
+                                                                                                                              currency: "0x0000000000000000000000000000000000000000",
+                                                                                                                              balance: "0.2",
+                                                                                                                              symbol: "ETH",
+                                                                                                                              value: Immutable.Map {
+                                                                                                                                                eth: "0.2",
+                                                                                                                                                btc: "0.002",
+                                                                                                                                                usd: "82.4",
+                                                                                                                              },
+                                                                                                            },
+                                                                                                            Immutable.Map {
+                                                                                                                              currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                                              balance: "0.13",
+                                                                                                                              symbol: "BOKKY",
+                                                                                                                              value: Immutable.Map {
+                                                                                                                                                eth: "0.013",
+                                                                                                                                                btc: "0.00013",
+                                                                                                                                                usd: "0.13",
+                                                                                                                              },
+                                                                                                            },
+                                                                                          ],
+                                                                                          total: Immutable.Map {
+                                                                                                            eth: "0.213",
+                                                                                                            btc: "0.00213",
+                                                                                                            usd: "82.53",
+                                                                                          },
+                                                                        },
                                                                         combined: Immutable.Map {
                                                                                           loading: false,
                                                                                           error: null,
@@ -5508,6 +5756,37 @@ ShallowWrapper {
                                                                                 usd: "82.53",
                                                             },
                                         },
+                                        nahmiiActive: Immutable.Map {
+                                                            loading: false,
+                                                            error: null,
+                                                            assets: Immutable.List [
+                                                                                Immutable.Map {
+                                                                                                    currency: "0x0000000000000000000000000000000000000000",
+                                                                                                    balance: "0.2",
+                                                                                                    symbol: "ETH",
+                                                                                                    value: Immutable.Map {
+                                                                                                                        eth: "0.2",
+                                                                                                                        btc: "0.002",
+                                                                                                                        usd: "82.4",
+                                                                                                    },
+                                                                                },
+                                                                                Immutable.Map {
+                                                                                                    currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                    balance: "0.13",
+                                                                                                    symbol: "BOKKY",
+                                                                                                    value: Immutable.Map {
+                                                                                                                        eth: "0.013",
+                                                                                                                        btc: "0.00013",
+                                                                                                                        usd: "0.13",
+                                                                                                    },
+                                                                                },
+                                                            ],
+                                                            total: Immutable.Map {
+                                                                                eth: "0.213",
+                                                                                btc: "0.00213",
+                                                                                usd: "82.53",
+                                                            },
+                                        },
                                         combined: Immutable.Map {
                                                             loading: false,
                                                             error: null,
@@ -5796,6 +6075,37 @@ ShallowWrapper {
                     },
                 },
                 nahmiiCombined: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
+                nahmiiActive: Immutable.Map {
                     loading: false,
                     error: null,
                     assets: Immutable.List [
@@ -6418,6 +6728,37 @@ ShallowWrapper {
                                                                                 usd: "82.53",
                                                                       },
                                                             },
+                                                            nahmiiActive: Immutable.Map {
+                                                                      loading: false,
+                                                                      error: null,
+                                                                      assets: Immutable.List [
+                                                                                Immutable.Map {
+                                                                                          currency: "0x0000000000000000000000000000000000000000",
+                                                                                          balance: "0.2",
+                                                                                          symbol: "ETH",
+                                                                                          value: Immutable.Map {
+                                                                                                    eth: "0.2",
+                                                                                                    btc: "0.002",
+                                                                                                    usd: "82.4",
+                                                                                          },
+                                                                                },
+                                                                                Immutable.Map {
+                                                                                          currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                          balance: "0.13",
+                                                                                          symbol: "BOKKY",
+                                                                                          value: Immutable.Map {
+                                                                                                    eth: "0.013",
+                                                                                                    btc: "0.00013",
+                                                                                                    usd: "0.13",
+                                                                                          },
+                                                                                },
+                                                                      ],
+                                                                      total: Immutable.Map {
+                                                                                eth: "0.213",
+                                                                                btc: "0.00213",
+                                                                                usd: "82.53",
+                                                                      },
+                                                            },
                                                             combined: Immutable.Map {
                                                                       loading: false,
                                                                       error: null,
@@ -6904,6 +7245,37 @@ ShallowWrapper {
                                                                                     },
                                                                       },
                                                                       nahmiiCombined: Immutable.Map {
+                                                                                    loading: false,
+                                                                                    error: null,
+                                                                                    assets: Immutable.List [
+                                                                                                  Immutable.Map {
+                                                                                                                currency: "0x0000000000000000000000000000000000000000",
+                                                                                                                balance: "0.2",
+                                                                                                                symbol: "ETH",
+                                                                                                                value: Immutable.Map {
+                                                                                                                              eth: "0.2",
+                                                                                                                              btc: "0.002",
+                                                                                                                              usd: "82.4",
+                                                                                                                },
+                                                                                                  },
+                                                                                                  Immutable.Map {
+                                                                                                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                                balance: "0.13",
+                                                                                                                symbol: "BOKKY",
+                                                                                                                value: Immutable.Map {
+                                                                                                                              eth: "0.013",
+                                                                                                                              btc: "0.00013",
+                                                                                                                              usd: "0.13",
+                                                                                                                },
+                                                                                                  },
+                                                                                    ],
+                                                                                    total: Immutable.Map {
+                                                                                                  eth: "0.213",
+                                                                                                  btc: "0.00213",
+                                                                                                  usd: "82.53",
+                                                                                    },
+                                                                      },
+                                                                      nahmiiActive: Immutable.Map {
                                                                                     loading: false,
                                                                                     error: null,
                                                                                     assets: Immutable.List [
@@ -7881,6 +8253,37 @@ ShallowWrapper {
                                                                                                 usd: "82.53",
                                                                                 },
                                                                 },
+                                                                nahmiiActive: Immutable.Map {
+                                                                                loading: false,
+                                                                                error: null,
+                                                                                assets: Immutable.List [
+                                                                                                Immutable.Map {
+                                                                                                                currency: "0x0000000000000000000000000000000000000000",
+                                                                                                                balance: "0.2",
+                                                                                                                symbol: "ETH",
+                                                                                                                value: Immutable.Map {
+                                                                                                                                eth: "0.2",
+                                                                                                                                btc: "0.002",
+                                                                                                                                usd: "82.4",
+                                                                                                                },
+                                                                                                },
+                                                                                                Immutable.Map {
+                                                                                                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                                balance: "0.13",
+                                                                                                                symbol: "BOKKY",
+                                                                                                                value: Immutable.Map {
+                                                                                                                                eth: "0.013",
+                                                                                                                                btc: "0.00013",
+                                                                                                                                usd: "0.13",
+                                                                                                                },
+                                                                                                },
+                                                                                ],
+                                                                                total: Immutable.Map {
+                                                                                                eth: "0.213",
+                                                                                                btc: "0.00213",
+                                                                                                usd: "82.53",
+                                                                                },
+                                                                },
                                                                 combined: Immutable.Map {
                                                                                 loading: false,
                                                                                 error: null,
@@ -8170,6 +8573,37 @@ ShallowWrapper {
                                                       },
                                     },
                                     nahmiiCombined: Immutable.Map {
+                                                      loading: false,
+                                                      error: null,
+                                                      assets: Immutable.List [
+                                                                        Immutable.Map {
+                                                                                          currency: "0x0000000000000000000000000000000000000000",
+                                                                                          balance: "0.2",
+                                                                                          symbol: "ETH",
+                                                                                          value: Immutable.Map {
+                                                                                                            eth: "0.2",
+                                                                                                            btc: "0.002",
+                                                                                                            usd: "82.4",
+                                                                                          },
+                                                                        },
+                                                                        Immutable.Map {
+                                                                                          currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                          balance: "0.13",
+                                                                                          symbol: "BOKKY",
+                                                                                          value: Immutable.Map {
+                                                                                                            eth: "0.013",
+                                                                                                            btc: "0.00013",
+                                                                                                            usd: "0.13",
+                                                                                          },
+                                                                        },
+                                                      ],
+                                                      total: Immutable.Map {
+                                                                        eth: "0.213",
+                                                                        btc: "0.00213",
+                                                                        usd: "82.53",
+                                                      },
+                                    },
+                                    nahmiiActive: Immutable.Map {
                                                       loading: false,
                                                       error: null,
                                                       assets: Immutable.List [
@@ -8703,6 +9137,37 @@ ShallowWrapper {
                                                                                                 usd: "82.53",
                                                                                     },
                                                                         },
+                                                                        nahmiiActive: Immutable.Map {
+                                                                                    loading: false,
+                                                                                    error: null,
+                                                                                    assets: Immutable.List [
+                                                                                                Immutable.Map {
+                                                                                                            currency: "0x0000000000000000000000000000000000000000",
+                                                                                                            balance: "0.2",
+                                                                                                            symbol: "ETH",
+                                                                                                            value: Immutable.Map {
+                                                                                                                        eth: "0.2",
+                                                                                                                        btc: "0.002",
+                                                                                                                        usd: "82.4",
+                                                                                                            },
+                                                                                                },
+                                                                                                Immutable.Map {
+                                                                                                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                            balance: "0.13",
+                                                                                                            symbol: "BOKKY",
+                                                                                                            value: Immutable.Map {
+                                                                                                                        eth: "0.013",
+                                                                                                                        btc: "0.00013",
+                                                                                                                        usd: "0.13",
+                                                                                                            },
+                                                                                                },
+                                                                                    ],
+                                                                                    total: Immutable.Map {
+                                                                                                eth: "0.213",
+                                                                                                btc: "0.00213",
+                                                                                                usd: "82.53",
+                                                                                    },
+                                                                        },
                                                                         combined: Immutable.Map {
                                                                                     loading: false,
                                                                                     error: null,
@@ -9189,6 +9654,37 @@ ShallowWrapper {
                                                                                                 },
                                                                                 },
                                                                                 nahmiiCombined: Immutable.Map {
+                                                                                                loading: false,
+                                                                                                error: null,
+                                                                                                assets: Immutable.List [
+                                                                                                                Immutable.Map {
+                                                                                                                                currency: "0x0000000000000000000000000000000000000000",
+                                                                                                                                balance: "0.2",
+                                                                                                                                symbol: "ETH",
+                                                                                                                                value: Immutable.Map {
+                                                                                                                                                eth: "0.2",
+                                                                                                                                                btc: "0.002",
+                                                                                                                                                usd: "82.4",
+                                                                                                                                },
+                                                                                                                },
+                                                                                                                Immutable.Map {
+                                                                                                                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                                                balance: "0.13",
+                                                                                                                                symbol: "BOKKY",
+                                                                                                                                value: Immutable.Map {
+                                                                                                                                                eth: "0.013",
+                                                                                                                                                btc: "0.00013",
+                                                                                                                                                usd: "0.13",
+                                                                                                                                },
+                                                                                                                },
+                                                                                                ],
+                                                                                                total: Immutable.Map {
+                                                                                                                eth: "0.213",
+                                                                                                                btc: "0.00213",
+                                                                                                                usd: "82.53",
+                                                                                                },
+                                                                                },
+                                                                                nahmiiActive: Immutable.Map {
                                                                                                 loading: false,
                                                                                                 error: null,
                                                                                                 assets: Immutable.List [
@@ -10166,6 +10662,37 @@ ShallowWrapper {
                                                                                                             usd: "82.53",
                                                                                           },
                                                                         },
+                                                                        nahmiiActive: Immutable.Map {
+                                                                                          loading: false,
+                                                                                          error: null,
+                                                                                          assets: Immutable.List [
+                                                                                                            Immutable.Map {
+                                                                                                                              currency: "0x0000000000000000000000000000000000000000",
+                                                                                                                              balance: "0.2",
+                                                                                                                              symbol: "ETH",
+                                                                                                                              value: Immutable.Map {
+                                                                                                                                                eth: "0.2",
+                                                                                                                                                btc: "0.002",
+                                                                                                                                                usd: "82.4",
+                                                                                                                              },
+                                                                                                            },
+                                                                                                            Immutable.Map {
+                                                                                                                              currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                                              balance: "0.13",
+                                                                                                                              symbol: "BOKKY",
+                                                                                                                              value: Immutable.Map {
+                                                                                                                                                eth: "0.013",
+                                                                                                                                                btc: "0.00013",
+                                                                                                                                                usd: "0.13",
+                                                                                                                              },
+                                                                                                            },
+                                                                                          ],
+                                                                                          total: Immutable.Map {
+                                                                                                            eth: "0.213",
+                                                                                                            btc: "0.00213",
+                                                                                                            usd: "82.53",
+                                                                                          },
+                                                                        },
                                                                         combined: Immutable.Map {
                                                                                           loading: false,
                                                                                           error: null,
@@ -10485,6 +11012,37 @@ ShallowWrapper {
                                                                                 usd: "82.53",
                                                             },
                                         },
+                                        nahmiiActive: Immutable.Map {
+                                                            loading: false,
+                                                            error: null,
+                                                            assets: Immutable.List [
+                                                                                Immutable.Map {
+                                                                                                    currency: "0x0000000000000000000000000000000000000000",
+                                                                                                    balance: "0.2",
+                                                                                                    symbol: "ETH",
+                                                                                                    value: Immutable.Map {
+                                                                                                                        eth: "0.2",
+                                                                                                                        btc: "0.002",
+                                                                                                                        usd: "82.4",
+                                                                                                    },
+                                                                                },
+                                                                                Immutable.Map {
+                                                                                                    currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                    balance: "0.13",
+                                                                                                    symbol: "BOKKY",
+                                                                                                    value: Immutable.Map {
+                                                                                                                        eth: "0.013",
+                                                                                                                        btc: "0.00013",
+                                                                                                                        usd: "0.13",
+                                                                                                    },
+                                                                                },
+                                                            ],
+                                                            total: Immutable.Map {
+                                                                                eth: "0.213",
+                                                                                btc: "0.00213",
+                                                                                usd: "82.53",
+                                                            },
+                                        },
                                         combined: Immutable.Map {
                                                             loading: false,
                                                             error: null,
@@ -10773,6 +11331,37 @@ ShallowWrapper {
                     },
                 },
                 nahmiiCombined: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
+                nahmiiActive: Immutable.Map {
                     loading: false,
                     error: null,
                     assets: Immutable.List [
@@ -11467,6 +12056,37 @@ ShallowWrapper {
                                                                                 usd: "82.53",
                                                                       },
                                                             },
+                                                            nahmiiActive: Immutable.Map {
+                                                                      loading: false,
+                                                                      error: null,
+                                                                      assets: Immutable.List [
+                                                                                Immutable.Map {
+                                                                                          currency: "0x0000000000000000000000000000000000000000",
+                                                                                          balance: "0.2",
+                                                                                          symbol: "ETH",
+                                                                                          value: Immutable.Map {
+                                                                                                    eth: "0.2",
+                                                                                                    btc: "0.002",
+                                                                                                    usd: "82.4",
+                                                                                          },
+                                                                                },
+                                                                                Immutable.Map {
+                                                                                          currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                          balance: "0.13",
+                                                                                          symbol: "BOKKY",
+                                                                                          value: Immutable.Map {
+                                                                                                    eth: "0.013",
+                                                                                                    btc: "0.00013",
+                                                                                                    usd: "0.13",
+                                                                                          },
+                                                                                },
+                                                                      ],
+                                                                      total: Immutable.Map {
+                                                                                eth: "0.213",
+                                                                                btc: "0.00213",
+                                                                                usd: "82.53",
+                                                                      },
+                                                            },
                                                             combined: Immutable.Map {
                                                                       loading: false,
                                                                       error: null,
@@ -12023,6 +12643,37 @@ ShallowWrapper {
                                                                                     },
                                                                       },
                                                                       nahmiiCombined: Immutable.Map {
+                                                                                    loading: false,
+                                                                                    error: null,
+                                                                                    assets: Immutable.List [
+                                                                                                  Immutable.Map {
+                                                                                                                currency: "0x0000000000000000000000000000000000000000",
+                                                                                                                balance: "0.2",
+                                                                                                                symbol: "ETH",
+                                                                                                                value: Immutable.Map {
+                                                                                                                              eth: "0.2",
+                                                                                                                              btc: "0.002",
+                                                                                                                              usd: "82.4",
+                                                                                                                },
+                                                                                                  },
+                                                                                                  Immutable.Map {
+                                                                                                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                                balance: "0.13",
+                                                                                                                symbol: "BOKKY",
+                                                                                                                value: Immutable.Map {
+                                                                                                                              eth: "0.013",
+                                                                                                                              btc: "0.00013",
+                                                                                                                              usd: "0.13",
+                                                                                                                },
+                                                                                                  },
+                                                                                    ],
+                                                                                    total: Immutable.Map {
+                                                                                                  eth: "0.213",
+                                                                                                  btc: "0.00213",
+                                                                                                  usd: "82.53",
+                                                                                    },
+                                                                      },
+                                                                      nahmiiActive: Immutable.Map {
                                                                                     loading: false,
                                                                                     error: null,
                                                                                     assets: Immutable.List [
@@ -13166,6 +13817,37 @@ ShallowWrapper {
                                                                                                 usd: "82.53",
                                                                                 },
                                                                 },
+                                                                nahmiiActive: Immutable.Map {
+                                                                                loading: false,
+                                                                                error: null,
+                                                                                assets: Immutable.List [
+                                                                                                Immutable.Map {
+                                                                                                                currency: "0x0000000000000000000000000000000000000000",
+                                                                                                                balance: "0.2",
+                                                                                                                symbol: "ETH",
+                                                                                                                value: Immutable.Map {
+                                                                                                                                eth: "0.2",
+                                                                                                                                btc: "0.002",
+                                                                                                                                usd: "82.4",
+                                                                                                                },
+                                                                                                },
+                                                                                                Immutable.Map {
+                                                                                                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                                balance: "0.13",
+                                                                                                                symbol: "BOKKY",
+                                                                                                                value: Immutable.Map {
+                                                                                                                                eth: "0.013",
+                                                                                                                                btc: "0.00013",
+                                                                                                                                usd: "0.13",
+                                                                                                                },
+                                                                                                },
+                                                                                ],
+                                                                                total: Immutable.Map {
+                                                                                                eth: "0.213",
+                                                                                                btc: "0.00213",
+                                                                                                usd: "82.53",
+                                                                                },
+                                                                },
                                                                 combined: Immutable.Map {
                                                                                 loading: false,
                                                                                 error: null,
@@ -13455,6 +14137,37 @@ ShallowWrapper {
                                                       },
                                     },
                                     nahmiiCombined: Immutable.Map {
+                                                      loading: false,
+                                                      error: null,
+                                                      assets: Immutable.List [
+                                                                        Immutable.Map {
+                                                                                          currency: "0x0000000000000000000000000000000000000000",
+                                                                                          balance: "0.2",
+                                                                                          symbol: "ETH",
+                                                                                          value: Immutable.Map {
+                                                                                                            eth: "0.2",
+                                                                                                            btc: "0.002",
+                                                                                                            usd: "82.4",
+                                                                                          },
+                                                                        },
+                                                                        Immutable.Map {
+                                                                                          currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                          balance: "0.13",
+                                                                                          symbol: "BOKKY",
+                                                                                          value: Immutable.Map {
+                                                                                                            eth: "0.013",
+                                                                                                            btc: "0.00013",
+                                                                                                            usd: "0.13",
+                                                                                          },
+                                                                        },
+                                                      ],
+                                                      total: Immutable.Map {
+                                                                        eth: "0.213",
+                                                                        btc: "0.00213",
+                                                                        usd: "82.53",
+                                                      },
+                                    },
+                                    nahmiiActive: Immutable.Map {
                                                       loading: false,
                                                       error: null,
                                                       assets: Immutable.List [
@@ -14045,6 +14758,37 @@ ShallowWrapper {
                                                                                                 usd: "82.53",
                                                                                     },
                                                                         },
+                                                                        nahmiiActive: Immutable.Map {
+                                                                                    loading: false,
+                                                                                    error: null,
+                                                                                    assets: Immutable.List [
+                                                                                                Immutable.Map {
+                                                                                                            currency: "0x0000000000000000000000000000000000000000",
+                                                                                                            balance: "0.2",
+                                                                                                            symbol: "ETH",
+                                                                                                            value: Immutable.Map {
+                                                                                                                        eth: "0.2",
+                                                                                                                        btc: "0.002",
+                                                                                                                        usd: "82.4",
+                                                                                                            },
+                                                                                                },
+                                                                                                Immutable.Map {
+                                                                                                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                            balance: "0.13",
+                                                                                                            symbol: "BOKKY",
+                                                                                                            value: Immutable.Map {
+                                                                                                                        eth: "0.013",
+                                                                                                                        btc: "0.00013",
+                                                                                                                        usd: "0.13",
+                                                                                                            },
+                                                                                                },
+                                                                                    ],
+                                                                                    total: Immutable.Map {
+                                                                                                eth: "0.213",
+                                                                                                btc: "0.00213",
+                                                                                                usd: "82.53",
+                                                                                    },
+                                                                        },
                                                                         combined: Immutable.Map {
                                                                                     loading: false,
                                                                                     error: null,
@@ -14601,6 +15345,37 @@ ShallowWrapper {
                                                                                                 },
                                                                                 },
                                                                                 nahmiiCombined: Immutable.Map {
+                                                                                                loading: false,
+                                                                                                error: null,
+                                                                                                assets: Immutable.List [
+                                                                                                                Immutable.Map {
+                                                                                                                                currency: "0x0000000000000000000000000000000000000000",
+                                                                                                                                balance: "0.2",
+                                                                                                                                symbol: "ETH",
+                                                                                                                                value: Immutable.Map {
+                                                                                                                                                eth: "0.2",
+                                                                                                                                                btc: "0.002",
+                                                                                                                                                usd: "82.4",
+                                                                                                                                },
+                                                                                                                },
+                                                                                                                Immutable.Map {
+                                                                                                                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                                                balance: "0.13",
+                                                                                                                                symbol: "BOKKY",
+                                                                                                                                value: Immutable.Map {
+                                                                                                                                                eth: "0.013",
+                                                                                                                                                btc: "0.00013",
+                                                                                                                                                usd: "0.13",
+                                                                                                                                },
+                                                                                                                },
+                                                                                                ],
+                                                                                                total: Immutable.Map {
+                                                                                                                eth: "0.213",
+                                                                                                                btc: "0.00213",
+                                                                                                                usd: "82.53",
+                                                                                                },
+                                                                                },
+                                                                                nahmiiActive: Immutable.Map {
                                                                                                 loading: false,
                                                                                                 error: null,
                                                                                                 assets: Immutable.List [
@@ -15744,6 +16519,37 @@ ShallowWrapper {
                                                                                                             usd: "82.53",
                                                                                           },
                                                                         },
+                                                                        nahmiiActive: Immutable.Map {
+                                                                                          loading: false,
+                                                                                          error: null,
+                                                                                          assets: Immutable.List [
+                                                                                                            Immutable.Map {
+                                                                                                                              currency: "0x0000000000000000000000000000000000000000",
+                                                                                                                              balance: "0.2",
+                                                                                                                              symbol: "ETH",
+                                                                                                                              value: Immutable.Map {
+                                                                                                                                                eth: "0.2",
+                                                                                                                                                btc: "0.002",
+                                                                                                                                                usd: "82.4",
+                                                                                                                              },
+                                                                                                            },
+                                                                                                            Immutable.Map {
+                                                                                                                              currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                                              balance: "0.13",
+                                                                                                                              symbol: "BOKKY",
+                                                                                                                              value: Immutable.Map {
+                                                                                                                                                eth: "0.013",
+                                                                                                                                                btc: "0.00013",
+                                                                                                                                                usd: "0.13",
+                                                                                                                              },
+                                                                                                            },
+                                                                                          ],
+                                                                                          total: Immutable.Map {
+                                                                                                            eth: "0.213",
+                                                                                                            btc: "0.00213",
+                                                                                                            usd: "82.53",
+                                                                                          },
+                                                                        },
                                                                         combined: Immutable.Map {
                                                                                           loading: false,
                                                                                           error: null,
@@ -16063,6 +16869,37 @@ ShallowWrapper {
                                                                                 usd: "82.53",
                                                             },
                                         },
+                                        nahmiiActive: Immutable.Map {
+                                                            loading: false,
+                                                            error: null,
+                                                            assets: Immutable.List [
+                                                                                Immutable.Map {
+                                                                                                    currency: "0x0000000000000000000000000000000000000000",
+                                                                                                    balance: "0.2",
+                                                                                                    symbol: "ETH",
+                                                                                                    value: Immutable.Map {
+                                                                                                                        eth: "0.2",
+                                                                                                                        btc: "0.002",
+                                                                                                                        usd: "82.4",
+                                                                                                    },
+                                                                                },
+                                                                                Immutable.Map {
+                                                                                                    currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                    balance: "0.13",
+                                                                                                    symbol: "BOKKY",
+                                                                                                    value: Immutable.Map {
+                                                                                                                        eth: "0.013",
+                                                                                                                        btc: "0.00013",
+                                                                                                                        usd: "0.13",
+                                                                                                    },
+                                                                                },
+                                                            ],
+                                                            total: Immutable.Map {
+                                                                                eth: "0.213",
+                                                                                btc: "0.00213",
+                                                                                usd: "82.53",
+                                                            },
+                                        },
                                         combined: Immutable.Map {
                                                             loading: false,
                                                             error: null,
@@ -16351,6 +17188,37 @@ ShallowWrapper {
                     },
                 },
                 nahmiiCombined: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
+                nahmiiActive: Immutable.Map {
                     loading: false,
                     error: null,
                     assets: Immutable.List [
@@ -17045,6 +17913,37 @@ ShallowWrapper {
                                                                                 usd: "82.53",
                                                                       },
                                                             },
+                                                            nahmiiActive: Immutable.Map {
+                                                                      loading: false,
+                                                                      error: null,
+                                                                      assets: Immutable.List [
+                                                                                Immutable.Map {
+                                                                                          currency: "0x0000000000000000000000000000000000000000",
+                                                                                          balance: "0.2",
+                                                                                          symbol: "ETH",
+                                                                                          value: Immutable.Map {
+                                                                                                    eth: "0.2",
+                                                                                                    btc: "0.002",
+                                                                                                    usd: "82.4",
+                                                                                          },
+                                                                                },
+                                                                                Immutable.Map {
+                                                                                          currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                          balance: "0.13",
+                                                                                          symbol: "BOKKY",
+                                                                                          value: Immutable.Map {
+                                                                                                    eth: "0.013",
+                                                                                                    btc: "0.00013",
+                                                                                                    usd: "0.13",
+                                                                                          },
+                                                                                },
+                                                                      ],
+                                                                      total: Immutable.Map {
+                                                                                eth: "0.213",
+                                                                                btc: "0.00213",
+                                                                                usd: "82.53",
+                                                                      },
+                                                            },
                                                             combined: Immutable.Map {
                                                                       loading: false,
                                                                       error: null,
@@ -17601,6 +18500,37 @@ ShallowWrapper {
                                                                                     },
                                                                       },
                                                                       nahmiiCombined: Immutable.Map {
+                                                                                    loading: false,
+                                                                                    error: null,
+                                                                                    assets: Immutable.List [
+                                                                                                  Immutable.Map {
+                                                                                                                currency: "0x0000000000000000000000000000000000000000",
+                                                                                                                balance: "0.2",
+                                                                                                                symbol: "ETH",
+                                                                                                                value: Immutable.Map {
+                                                                                                                              eth: "0.2",
+                                                                                                                              btc: "0.002",
+                                                                                                                              usd: "82.4",
+                                                                                                                },
+                                                                                                  },
+                                                                                                  Immutable.Map {
+                                                                                                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                                balance: "0.13",
+                                                                                                                symbol: "BOKKY",
+                                                                                                                value: Immutable.Map {
+                                                                                                                              eth: "0.013",
+                                                                                                                              btc: "0.00013",
+                                                                                                                              usd: "0.13",
+                                                                                                                },
+                                                                                                  },
+                                                                                    ],
+                                                                                    total: Immutable.Map {
+                                                                                                  eth: "0.213",
+                                                                                                  btc: "0.00213",
+                                                                                                  usd: "82.53",
+                                                                                    },
+                                                                      },
+                                                                      nahmiiActive: Immutable.Map {
                                                                                     loading: false,
                                                                                     error: null,
                                                                                     assets: Immutable.List [
@@ -18744,6 +19674,37 @@ ShallowWrapper {
                                                                                                 usd: "82.53",
                                                                                 },
                                                                 },
+                                                                nahmiiActive: Immutable.Map {
+                                                                                loading: false,
+                                                                                error: null,
+                                                                                assets: Immutable.List [
+                                                                                                Immutable.Map {
+                                                                                                                currency: "0x0000000000000000000000000000000000000000",
+                                                                                                                balance: "0.2",
+                                                                                                                symbol: "ETH",
+                                                                                                                value: Immutable.Map {
+                                                                                                                                eth: "0.2",
+                                                                                                                                btc: "0.002",
+                                                                                                                                usd: "82.4",
+                                                                                                                },
+                                                                                                },
+                                                                                                Immutable.Map {
+                                                                                                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                                balance: "0.13",
+                                                                                                                symbol: "BOKKY",
+                                                                                                                value: Immutable.Map {
+                                                                                                                                eth: "0.013",
+                                                                                                                                btc: "0.00013",
+                                                                                                                                usd: "0.13",
+                                                                                                                },
+                                                                                                },
+                                                                                ],
+                                                                                total: Immutable.Map {
+                                                                                                eth: "0.213",
+                                                                                                btc: "0.00213",
+                                                                                                usd: "82.53",
+                                                                                },
+                                                                },
                                                                 combined: Immutable.Map {
                                                                                 loading: false,
                                                                                 error: null,
@@ -19033,6 +19994,37 @@ ShallowWrapper {
                                                       },
                                     },
                                     nahmiiCombined: Immutable.Map {
+                                                      loading: false,
+                                                      error: null,
+                                                      assets: Immutable.List [
+                                                                        Immutable.Map {
+                                                                                          currency: "0x0000000000000000000000000000000000000000",
+                                                                                          balance: "0.2",
+                                                                                          symbol: "ETH",
+                                                                                          value: Immutable.Map {
+                                                                                                            eth: "0.2",
+                                                                                                            btc: "0.002",
+                                                                                                            usd: "82.4",
+                                                                                          },
+                                                                        },
+                                                                        Immutable.Map {
+                                                                                          currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                          balance: "0.13",
+                                                                                          symbol: "BOKKY",
+                                                                                          value: Immutable.Map {
+                                                                                                            eth: "0.013",
+                                                                                                            btc: "0.00013",
+                                                                                                            usd: "0.13",
+                                                                                          },
+                                                                        },
+                                                      ],
+                                                      total: Immutable.Map {
+                                                                        eth: "0.213",
+                                                                        btc: "0.00213",
+                                                                        usd: "82.53",
+                                                      },
+                                    },
+                                    nahmiiActive: Immutable.Map {
                                                       loading: false,
                                                       error: null,
                                                       assets: Immutable.List [
@@ -19623,6 +20615,37 @@ ShallowWrapper {
                                                                                                 usd: "82.53",
                                                                                     },
                                                                         },
+                                                                        nahmiiActive: Immutable.Map {
+                                                                                    loading: false,
+                                                                                    error: null,
+                                                                                    assets: Immutable.List [
+                                                                                                Immutable.Map {
+                                                                                                            currency: "0x0000000000000000000000000000000000000000",
+                                                                                                            balance: "0.2",
+                                                                                                            symbol: "ETH",
+                                                                                                            value: Immutable.Map {
+                                                                                                                        eth: "0.2",
+                                                                                                                        btc: "0.002",
+                                                                                                                        usd: "82.4",
+                                                                                                            },
+                                                                                                },
+                                                                                                Immutable.Map {
+                                                                                                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                            balance: "0.13",
+                                                                                                            symbol: "BOKKY",
+                                                                                                            value: Immutable.Map {
+                                                                                                                        eth: "0.013",
+                                                                                                                        btc: "0.00013",
+                                                                                                                        usd: "0.13",
+                                                                                                            },
+                                                                                                },
+                                                                                    ],
+                                                                                    total: Immutable.Map {
+                                                                                                eth: "0.213",
+                                                                                                btc: "0.00213",
+                                                                                                usd: "82.53",
+                                                                                    },
+                                                                        },
                                                                         combined: Immutable.Map {
                                                                                     loading: false,
                                                                                     error: null,
@@ -20179,6 +21202,37 @@ ShallowWrapper {
                                                                                                 },
                                                                                 },
                                                                                 nahmiiCombined: Immutable.Map {
+                                                                                                loading: false,
+                                                                                                error: null,
+                                                                                                assets: Immutable.List [
+                                                                                                                Immutable.Map {
+                                                                                                                                currency: "0x0000000000000000000000000000000000000000",
+                                                                                                                                balance: "0.2",
+                                                                                                                                symbol: "ETH",
+                                                                                                                                value: Immutable.Map {
+                                                                                                                                                eth: "0.2",
+                                                                                                                                                btc: "0.002",
+                                                                                                                                                usd: "82.4",
+                                                                                                                                },
+                                                                                                                },
+                                                                                                                Immutable.Map {
+                                                                                                                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                                                balance: "0.13",
+                                                                                                                                symbol: "BOKKY",
+                                                                                                                                value: Immutable.Map {
+                                                                                                                                                eth: "0.013",
+                                                                                                                                                btc: "0.00013",
+                                                                                                                                                usd: "0.13",
+                                                                                                                                },
+                                                                                                                },
+                                                                                                ],
+                                                                                                total: Immutable.Map {
+                                                                                                                eth: "0.213",
+                                                                                                                btc: "0.00213",
+                                                                                                                usd: "82.53",
+                                                                                                },
+                                                                                },
+                                                                                nahmiiActive: Immutable.Map {
                                                                                                 loading: false,
                                                                                                 error: null,
                                                                                                 assets: Immutable.List [
@@ -21322,6 +22376,37 @@ ShallowWrapper {
                                                                                                             usd: "82.53",
                                                                                           },
                                                                         },
+                                                                        nahmiiActive: Immutable.Map {
+                                                                                          loading: false,
+                                                                                          error: null,
+                                                                                          assets: Immutable.List [
+                                                                                                            Immutable.Map {
+                                                                                                                              currency: "0x0000000000000000000000000000000000000000",
+                                                                                                                              balance: "0.2",
+                                                                                                                              symbol: "ETH",
+                                                                                                                              value: Immutable.Map {
+                                                                                                                                                eth: "0.2",
+                                                                                                                                                btc: "0.002",
+                                                                                                                                                usd: "82.4",
+                                                                                                                              },
+                                                                                                            },
+                                                                                                            Immutable.Map {
+                                                                                                                              currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                                              balance: "0.13",
+                                                                                                                              symbol: "BOKKY",
+                                                                                                                              value: Immutable.Map {
+                                                                                                                                                eth: "0.013",
+                                                                                                                                                btc: "0.00013",
+                                                                                                                                                usd: "0.13",
+                                                                                                                              },
+                                                                                                            },
+                                                                                          ],
+                                                                                          total: Immutable.Map {
+                                                                                                            eth: "0.213",
+                                                                                                            btc: "0.00213",
+                                                                                                            usd: "82.53",
+                                                                                          },
+                                                                        },
                                                                         combined: Immutable.Map {
                                                                                           loading: false,
                                                                                           error: null,
@@ -21611,6 +22696,37 @@ ShallowWrapper {
                                                             },
                                         },
                                         nahmiiCombined: Immutable.Map {
+                                                            loading: false,
+                                                            error: null,
+                                                            assets: Immutable.List [
+                                                                                Immutable.Map {
+                                                                                                    currency: "0x0000000000000000000000000000000000000000",
+                                                                                                    balance: "0.2",
+                                                                                                    symbol: "ETH",
+                                                                                                    value: Immutable.Map {
+                                                                                                                        eth: "0.2",
+                                                                                                                        btc: "0.002",
+                                                                                                                        usd: "82.4",
+                                                                                                    },
+                                                                                },
+                                                                                Immutable.Map {
+                                                                                                    currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                                    balance: "0.13",
+                                                                                                    symbol: "BOKKY",
+                                                                                                    value: Immutable.Map {
+                                                                                                                        eth: "0.013",
+                                                                                                                        btc: "0.00013",
+                                                                                                                        usd: "0.13",
+                                                                                                    },
+                                                                                },
+                                                            ],
+                                                            total: Immutable.Map {
+                                                                                eth: "0.213",
+                                                                                btc: "0.00213",
+                                                                                usd: "82.53",
+                                                            },
+                                        },
+                                        nahmiiActive: Immutable.Map {
                                                             loading: false,
                                                             error: null,
                                                             assets: Immutable.List [

--- a/src/containers/HWPromptContainer/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/HWPromptContainer/tests/__snapshots__/index.test.js.snap
@@ -138,6 +138,37 @@ ShallowWrapper {
                         usd: "82.53",
                     },
                 },
+                nahmiiActive: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
                 combined: Immutable.Map {
                     loading: false,
                     error: null,
@@ -441,6 +472,37 @@ ShallowWrapper {
                     },
                 },
                 nahmiiCombined: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
+                nahmiiActive: Immutable.Map {
                     loading: false,
                     error: null,
                     assets: Immutable.List [

--- a/src/containers/NahmiiDeposit/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/NahmiiDeposit/tests/__snapshots__/index.test.js.snap
@@ -247,6 +247,37 @@ ShallowWrapper {
                         usd: "82.53",
                     },
                 },
+                nahmiiActive: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
                 combined: Immutable.Map {
                     loading: false,
                     error: null,
@@ -5170,6 +5201,37 @@ ShallowWrapper {
                     },
                 },
                 nahmiiCombined: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
+                nahmiiActive: Immutable.Map {
                     loading: false,
                     error: null,
                     assets: Immutable.List [
@@ -10153,6 +10215,37 @@ ShallowWrapper {
                         usd: "82.53",
                     },
                 },
+                nahmiiActive: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
                 combined: Immutable.Map {
                     loading: false,
                     error: null,
@@ -14646,6 +14739,37 @@ ShallowWrapper {
                     },
                 },
                 nahmiiCombined: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
+                nahmiiActive: Immutable.Map {
                     loading: false,
                     error: null,
                     assets: Immutable.List [
@@ -19629,6 +19753,37 @@ ShallowWrapper {
                         usd: "82.53",
                     },
                 },
+                nahmiiActive: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
                 combined: Immutable.Map {
                     loading: false,
                     error: null,
@@ -24122,6 +24277,37 @@ ShallowWrapper {
                     },
                 },
                 nahmiiCombined: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
+                nahmiiActive: Immutable.Map {
                     loading: false,
                     error: null,
                     assets: Immutable.List [
@@ -28676,6 +28862,37 @@ ShallowWrapper {
                         usd: "82.53",
                     },
                 },
+                nahmiiActive: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
                 combined: Immutable.Map {
                     loading: false,
                     error: null,
@@ -29064,6 +29281,37 @@ ShallowWrapper {
                     },
                 },
                 nahmiiCombined: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
+                nahmiiActive: Immutable.Map {
                     loading: false,
                     error: null,
                     assets: Immutable.List [
@@ -29540,6 +29788,37 @@ ShallowWrapper {
                         usd: "82.53",
                     },
                 },
+                nahmiiActive: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
                 combined: Immutable.Map {
                     loading: false,
                     error: null,
@@ -29933,6 +30212,37 @@ ShallowWrapper {
                     },
                 },
                 nahmiiCombined: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
+                nahmiiActive: Immutable.Map {
                     loading: false,
                     error: null,
                     assets: Immutable.List [
@@ -30384,6 +30694,37 @@ ShallowWrapper {
                     },
                 },
                 nahmiiCombined: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
+                nahmiiActive: Immutable.Map {
                     loading: false,
                     error: null,
                     assets: Immutable.List [

--- a/src/containers/NahmiiHoc/combined-selectors.js
+++ b/src/containers/NahmiiHoc/combined-selectors.js
@@ -236,11 +236,13 @@ const makeSelectWalletsWithInfo = () => createSelector(
         }, combined);
       };
 
-      const nahmiiCombined = calcCombinedBalances('baseLayer', 'nahmiiStaged');
+      const nahmiiCombined = calcCombinedBalances('baseLayer');
+      const nahmiiActive = calcCombinedBalances('baseLayer', 'nahmiiStaged');
       const combined = calcCombinedBalances('nahmiiStaged');
 
       walletWithInfo = walletWithInfo
         .setIn(['balances', 'nahmiiCombined'], nahmiiCombined)
+        .setIn(['balances', 'nahmiiActive'], nahmiiActive)
         .setIn(['balances', 'combined'], combined);
 
       return walletWithInfo;
@@ -357,7 +359,10 @@ const makeSelectTotalBalances = () => createSelector(
     totalBalances.forEach((balance, balanceType) => {
       balance.get('assets').forEach((assetDetails, asset) => {
         calcCombinedBalances(assetDetails, asset, 'combined');
-        if (balanceType !== 'baseLayer') calcCombinedBalances(assetDetails, asset, 'nahmiiCombined');
+        if (balanceType !== 'baseLayer') {
+          calcCombinedBalances(assetDetails, asset, 'nahmiiActive');
+          calcCombinedBalances(assetDetails, asset, 'nahmiiCombined');
+        }
       });
     });
     return totalBalances;

--- a/src/containers/NahmiiWithdraw/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/NahmiiWithdraw/tests/__snapshots__/index.test.js.snap
@@ -247,6 +247,37 @@ ShallowWrapper {
                         usd: "82.53",
                     },
                 },
+                nahmiiActive: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
                 combined: Immutable.Map {
                     loading: false,
                     error: null,

--- a/src/containers/WalletDetails/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/WalletDetails/tests/__snapshots__/index.test.js.snap
@@ -138,6 +138,37 @@ ShallowWrapper {
                         usd: "82.53",
                     },
                 },
+                nahmiiActive: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
                 combined: Immutable.Map {
                     loading: false,
                     error: null,

--- a/src/containers/WalletHoc/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/WalletHoc/tests/__snapshots__/index.test.js.snap
@@ -144,6 +144,37 @@ ShallowWrapper {
                         usd: "82.53",
                     },
                 },
+                nahmiiActive: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
                 combined: Immutable.Map {
                     loading: false,
                     error: null,
@@ -316,6 +347,37 @@ ShallowWrapper {
                                                   },
                                         },
                                         nahmiiCombined: Immutable.Map {
+                                                  loading: false,
+                                                  error: null,
+                                                  assets: Immutable.List [
+                                                            Immutable.Map {
+                                                                      currency: "0x0000000000000000000000000000000000000000",
+                                                                      balance: "0.2",
+                                                                      symbol: "ETH",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.2",
+                                                                                btc: "0.002",
+                                                                                usd: "82.4",
+                                                                      },
+                                                            },
+                                                            Immutable.Map {
+                                                                      currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                      balance: "0.13",
+                                                                      symbol: "BOKKY",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.013",
+                                                                                btc: "0.00013",
+                                                                                usd: "0.13",
+                                                                      },
+                                                            },
+                                                  ],
+                                                  total: Immutable.Map {
+                                                            eth: "0.213",
+                                                            btc: "0.00213",
+                                                            usd: "82.53",
+                                                  },
+                                        },
+                                        nahmiiActive: Immutable.Map {
                                                   loading: false,
                                                   error: null,
                                                   assets: Immutable.List [
@@ -548,6 +610,37 @@ ShallowWrapper {
                                     },
                         },
                         nahmiiCombined: Immutable.Map {
+                                    loading: false,
+                                    error: null,
+                                    assets: Immutable.List [
+                                                Immutable.Map {
+                                                            currency: "0x0000000000000000000000000000000000000000",
+                                                            balance: "0.2",
+                                                            symbol: "ETH",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.2",
+                                                                        btc: "0.002",
+                                                                        usd: "82.4",
+                                                            },
+                                                },
+                                                Immutable.Map {
+                                                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                            balance: "0.13",
+                                                            symbol: "BOKKY",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.013",
+                                                                        btc: "0.00013",
+                                                                        usd: "0.13",
+                                                            },
+                                                },
+                                    ],
+                                    total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                    },
+                        },
+                        nahmiiActive: Immutable.Map {
                                     loading: false,
                                     error: null,
                                     assets: Immutable.List [
@@ -873,6 +966,37 @@ ShallowWrapper {
                                                                         usd: "82.53",
                                                             },
                                                 },
+                                                nahmiiActive: Immutable.Map {
+                                                            loading: false,
+                                                            error: null,
+                                                            assets: Immutable.List [
+                                                                        Immutable.Map {
+                                                                                    currency: "0x0000000000000000000000000000000000000000",
+                                                                                    balance: "0.2",
+                                                                                    symbol: "ETH",
+                                                                                    value: Immutable.Map {
+                                                                                                eth: "0.2",
+                                                                                                btc: "0.002",
+                                                                                                usd: "82.4",
+                                                                                    },
+                                                                        },
+                                                                        Immutable.Map {
+                                                                                    currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                    balance: "0.13",
+                                                                                    symbol: "BOKKY",
+                                                                                    value: Immutable.Map {
+                                                                                                eth: "0.013",
+                                                                                                btc: "0.00013",
+                                                                                                usd: "0.13",
+                                                                                    },
+                                                                        },
+                                                            ],
+                                                            total: Immutable.Map {
+                                                                        eth: "0.213",
+                                                                        btc: "0.00213",
+                                                                        usd: "82.53",
+                                                            },
+                                                },
                                                 combined: Immutable.Map {
                                                             loading: false,
                                                             error: null,
@@ -1075,6 +1199,37 @@ ShallowWrapper {
                                           },
                             },
                             nahmiiCombined: Immutable.Map {
+                                          loading: false,
+                                          error: null,
+                                          assets: Immutable.List [
+                                                        Immutable.Map {
+                                                                      currency: "0x0000000000000000000000000000000000000000",
+                                                                      balance: "0.2",
+                                                                      symbol: "ETH",
+                                                                      value: Immutable.Map {
+                                                                                    eth: "0.2",
+                                                                                    btc: "0.002",
+                                                                                    usd: "82.4",
+                                                                      },
+                                                        },
+                                                        Immutable.Map {
+                                                                      currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                      balance: "0.13",
+                                                                      symbol: "BOKKY",
+                                                                      value: Immutable.Map {
+                                                                                    eth: "0.013",
+                                                                                    btc: "0.00013",
+                                                                                    usd: "0.13",
+                                                                      },
+                                                        },
+                                          ],
+                                          total: Immutable.Map {
+                                                        eth: "0.213",
+                                                        btc: "0.00213",
+                                                        usd: "82.53",
+                                          },
+                            },
+                            nahmiiActive: Immutable.Map {
                                           loading: false,
                                           error: null,
                                           assets: Immutable.List [
@@ -1408,6 +1563,37 @@ ShallowWrapper {
                         usd: "82.53",
                     },
                 },
+                nahmiiActive: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
                 combined: Immutable.Map {
                     loading: false,
                     error: null,
@@ -1580,6 +1766,37 @@ ShallowWrapper {
                                                   },
                                         },
                                         nahmiiCombined: Immutable.Map {
+                                                  loading: false,
+                                                  error: null,
+                                                  assets: Immutable.List [
+                                                            Immutable.Map {
+                                                                      currency: "0x0000000000000000000000000000000000000000",
+                                                                      balance: "0.2",
+                                                                      symbol: "ETH",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.2",
+                                                                                btc: "0.002",
+                                                                                usd: "82.4",
+                                                                      },
+                                                            },
+                                                            Immutable.Map {
+                                                                      currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                      balance: "0.13",
+                                                                      symbol: "BOKKY",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.013",
+                                                                                btc: "0.00013",
+                                                                                usd: "0.13",
+                                                                      },
+                                                            },
+                                                  ],
+                                                  total: Immutable.Map {
+                                                            eth: "0.213",
+                                                            btc: "0.00213",
+                                                            usd: "82.53",
+                                                  },
+                                        },
+                                        nahmiiActive: Immutable.Map {
                                                   loading: false,
                                                   error: null,
                                                   assets: Immutable.List [
@@ -1809,6 +2026,37 @@ ShallowWrapper {
                                     },
                         },
                         nahmiiCombined: Immutable.Map {
+                                    loading: false,
+                                    error: null,
+                                    assets: Immutable.List [
+                                                Immutable.Map {
+                                                            currency: "0x0000000000000000000000000000000000000000",
+                                                            balance: "0.2",
+                                                            symbol: "ETH",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.2",
+                                                                        btc: "0.002",
+                                                                        usd: "82.4",
+                                                            },
+                                                },
+                                                Immutable.Map {
+                                                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                            balance: "0.13",
+                                                            symbol: "BOKKY",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.013",
+                                                                        btc: "0.00013",
+                                                                        usd: "0.13",
+                                                            },
+                                                },
+                                    ],
+                                    total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                    },
+                        },
+                        nahmiiActive: Immutable.Map {
                                     loading: false,
                                     error: null,
                                     assets: Immutable.List [
@@ -2129,6 +2377,37 @@ ShallowWrapper {
                                                                         usd: "82.53",
                                                             },
                                                 },
+                                                nahmiiActive: Immutable.Map {
+                                                            loading: false,
+                                                            error: null,
+                                                            assets: Immutable.List [
+                                                                        Immutable.Map {
+                                                                                    currency: "0x0000000000000000000000000000000000000000",
+                                                                                    balance: "0.2",
+                                                                                    symbol: "ETH",
+                                                                                    value: Immutable.Map {
+                                                                                                eth: "0.2",
+                                                                                                btc: "0.002",
+                                                                                                usd: "82.4",
+                                                                                    },
+                                                                        },
+                                                                        Immutable.Map {
+                                                                                    currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                                    balance: "0.13",
+                                                                                    symbol: "BOKKY",
+                                                                                    value: Immutable.Map {
+                                                                                                eth: "0.013",
+                                                                                                btc: "0.00013",
+                                                                                                usd: "0.13",
+                                                                                    },
+                                                                        },
+                                                            ],
+                                                            total: Immutable.Map {
+                                                                        eth: "0.213",
+                                                                        btc: "0.00213",
+                                                                        usd: "82.53",
+                                                            },
+                                                },
                                                 combined: Immutable.Map {
                                                             loading: false,
                                                             error: null,
@@ -2328,6 +2607,37 @@ ShallowWrapper {
                                           },
                             },
                             nahmiiCombined: Immutable.Map {
+                                          loading: false,
+                                          error: null,
+                                          assets: Immutable.List [
+                                                        Immutable.Map {
+                                                                      currency: "0x0000000000000000000000000000000000000000",
+                                                                      balance: "0.2",
+                                                                      symbol: "ETH",
+                                                                      value: Immutable.Map {
+                                                                                    eth: "0.2",
+                                                                                    btc: "0.002",
+                                                                                    usd: "82.4",
+                                                                      },
+                                                        },
+                                                        Immutable.Map {
+                                                                      currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                      balance: "0.13",
+                                                                      symbol: "BOKKY",
+                                                                      value: Immutable.Map {
+                                                                                    eth: "0.013",
+                                                                                    btc: "0.00013",
+                                                                                    usd: "0.13",
+                                                                      },
+                                                        },
+                                          ],
+                                          total: Immutable.Map {
+                                                        eth: "0.213",
+                                                        btc: "0.00213",
+                                                        usd: "82.53",
+                                          },
+                            },
+                            nahmiiActive: Immutable.Map {
                                           loading: false,
                                           error: null,
                                           assets: Immutable.List [

--- a/src/containers/WalletHoc/tests/mocks/index.js
+++ b/src/containers/WalletHoc/tests/mocks/index.js
@@ -66,6 +66,7 @@ export const totalBalAllEmpty = fromJS({
   nahmiiAvailable: { assets: {}, loading: false, error: null, total: { usd: new BigNumber('0') } },
   nahmiiStaging: { assets: {}, loading: false, error: null, total: { usd: new BigNumber('0') } },
   nahmiiStaged: { assets: {}, loading: false, error: null, total: { usd: new BigNumber('0') } },
+  nahmiiActive: { assets: {}, loading: false, error: null, total: { usd: new BigNumber('0') } },
   nahmiiCombined: { assets: {}, loading: false, error: null, total: { usd: new BigNumber('0') } },
   combined: { assets: {}, loading: false, error: null, total: { usd: new BigNumber('0') } },
 });
@@ -75,6 +76,7 @@ export const totalBalAllError = fromJS({
   nahmiiAvailable: { assets: {}, loading: false, error: true, total: { usd: new BigNumber('0') } },
   nahmiiStaging: { assets: {}, loading: false, error: true, total: { usd: new BigNumber('0') } },
   nahmiiStaged: { assets: {}, loading: false, error: true, total: { usd: new BigNumber('0') } },
+  nahmiiActive: { assets: {}, loading: false, error: null, total: { usd: new BigNumber('0') } },
   nahmiiCombined: { assets: {}, loading: false, error: null, total: { usd: new BigNumber('0') } },
   combined: { assets: {}, loading: false, error: true, total: { usd: new BigNumber('0') } },
 });
@@ -84,6 +86,7 @@ export const totalBallAllLoading = fromJS({
   nahmiiAvailable: { assets: {}, loading: true, error: null, total: { usd: new BigNumber('0') } },
   nahmiiStaging: { assets: {}, loading: true, error: null, total: { usd: new BigNumber('0') } },
   nahmiiStaged: { assets: {}, loading: true, error: null, total: { usd: new BigNumber('0') } },
+  nahmiiActive: { assets: {}, loading: false, error: null, total: { usd: new BigNumber('0') } },
   nahmiiCombined: { assets: {}, loading: false, error: null, total: { usd: new BigNumber('0') } },
   combined: { assets: {}, loading: true, error: null, total: { usd: new BigNumber('0') } },
 });

--- a/src/containers/WalletHoc/tests/mocks/selectors.js
+++ b/src/containers/WalletHoc/tests/mocks/selectors.js
@@ -45,6 +45,15 @@ export const totalBalancesLoadedMock = fromJS({
   },
   nahmiiStaging: { assets: { '0x0000000000000000000000000000000000000000': { amount: new BigNumber('0.1'), value: { usd: new BigNumber('41.2') } } }, loading: false, error: null, total: { usd: new BigNumber('41.2') } },
   nahmiiStaged: { assets: {}, loading: false, error: null, total: { usd: new BigNumber('0') } },
+  nahmiiActive: {
+    assets: {
+      '0x0000000000000000000000000000000000000000': { value: { usd: new BigNumber('82.4') }, amount: new BigNumber('0.2') },
+      '0x583cbbb8a8443b38abcc0c956bece47340ea1367': { value: { usd: new BigNumber('0.13') }, amount: new BigNumber('0.13') },
+    },
+    loading: false,
+    error: null,
+    total: { usd: new BigNumber('82.53') },
+  },
   nahmiiCombined: {
     assets: {
       '0x0000000000000000000000000000000000000000': { value: { usd: new BigNumber('82.4') }, amount: new BigNumber('0.2') },
@@ -185,6 +194,37 @@ export const walletsWithInfoMock = fromJS([
           usd: new BigNumber('82.53'),
         },
       },
+      nahmiiActive: {
+        loading: false,
+        error: null,
+        assets: [
+          {
+            currency: '0x0000000000000000000000000000000000000000',
+            balance: new BigNumber('0.2'),
+            symbol: 'ETH',
+            value: {
+              eth: new BigNumber('0.2'),
+              btc: new BigNumber('0.002'),
+              usd: new BigNumber('82.4'),
+            },
+          },
+          {
+            currency: '0x583cbbb8a8443b38abcc0c956bece47340ea1367',
+            balance: new BigNumber('0.13'),
+            symbol: 'BOKKY',
+            value: {
+              eth: new BigNumber('0.013'),
+              btc: new BigNumber('0.00013'),
+              usd: new BigNumber('0.13'),
+            },
+          },
+        ],
+        total: {
+          eth: new BigNumber('0.213'),
+          btc: new BigNumber('0.00213'),
+          usd: new BigNumber('82.53'),
+        },
+      },
       combined: {
         loading: false,
         error: null,
@@ -229,6 +269,7 @@ export const walletsWithInfoMock = fromJS([
       nahmiiStaging: { loading: false, error: null, assets: [], total: { eth: new BigNumber('0'), btc: new BigNumber('0'), usd: new BigNumber('0') } },
       nahmiiStaged: { loading: false, error: null, assets: [], total: { eth: new BigNumber('0'), btc: new BigNumber('0'), usd: new BigNumber('0') } },
       nahmiiCombined: { loading: false, error: true, assets: [], total: { eth: new BigNumber('0'), btc: new BigNumber('0'), usd: new BigNumber('0') } },
+      nahmiiActive: { loading: false, error: true, assets: [], total: { eth: new BigNumber('0'), btc: new BigNumber('0'), usd: new BigNumber('0') } },
       combined: { loading: false, error: true, assets: [], total: { eth: new BigNumber('0'), btc: new BigNumber('0'), usd: new BigNumber('0') } },
     },
   },
@@ -248,6 +289,7 @@ export const walletsWithInfoMock = fromJS([
       nahmiiStaging: { loading: true, error: null, assets: [], total: { usd: new BigNumber('0'), eth: new BigNumber('0'), btc: new BigNumber('0') } },
       nahmiiStaged: { loading: false, error: null, assets: [], total: { eth: new BigNumber('0'), btc: new BigNumber('0'), usd: new BigNumber('0') } },
       nahmiiCombined: { loading: true, error: null, assets: [], total: { eth: new BigNumber('0'), btc: new BigNumber('0'), usd: new BigNumber('0') } },
+      nahmiiActive: { loading: true, error: null, assets: [], total: { eth: new BigNumber('0'), btc: new BigNumber('0'), usd: new BigNumber('0') } },
       combined: { loading: true, error: null, assets: [], total: { eth: new BigNumber('0'), btc: new BigNumber('0'), usd: new BigNumber('0') } },
     },
   },
@@ -263,6 +305,7 @@ export const walletsWithInfoMock = fromJS([
       nahmiiStaging: { loading: false, error: null, assets: [], total: { eth: new BigNumber('0'), btc: new BigNumber('0'), usd: new BigNumber('0') } },
       nahmiiStaged: { loading: false, error: null, assets: [], total: { eth: new BigNumber('0'), btc: new BigNumber('0'), usd: new BigNumber('0') } },
       nahmiiCombined: { loading: false, error: null, assets: [], total: { eth: new BigNumber('0'), btc: new BigNumber('0'), usd: new BigNumber('0') } },
+      nahmiiActive: { loading: false, error: null, assets: [], total: { eth: new BigNumber('0'), btc: new BigNumber('0'), usd: new BigNumber('0') } },
       combined: { loading: true, error: null, assets: [], total: { eth: new BigNumber('0'), btc: new BigNumber('0'), usd: new BigNumber('0') } },
     },
   },

--- a/src/containers/WalletTransfer/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/WalletTransfer/tests/__snapshots__/index.test.js.snap
@@ -270,6 +270,37 @@ ShallowWrapper {
                         usd: "82.53",
                     },
                 },
+                nahmiiActive: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
                 combined: Immutable.Map {
                     loading: false,
                     error: null,
@@ -717,6 +748,37 @@ ShallowWrapper {
                                                 usd: "82.53",
                                         },
                                 },
+                                nahmiiActive: Immutable.Map {
+                                        loading: false,
+                                        error: null,
+                                        assets: Immutable.List [
+                                                Immutable.Map {
+                                                        currency: "0x0000000000000000000000000000000000000000",
+                                                        balance: "0.2",
+                                                        symbol: "ETH",
+                                                        value: Immutable.Map {
+                                                                eth: "0.2",
+                                                                btc: "0.002",
+                                                                usd: "82.4",
+                                                        },
+                                                },
+                                                Immutable.Map {
+                                                        currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                        balance: "0.13",
+                                                        symbol: "BOKKY",
+                                                        value: Immutable.Map {
+                                                                eth: "0.013",
+                                                                btc: "0.00013",
+                                                                usd: "0.13",
+                                                        },
+                                                },
+                                        ],
+                                        total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                        },
+                                },
                                 combined: Immutable.Map {
                                         loading: false,
                                         error: null,
@@ -1093,6 +1155,37 @@ ShallowWrapper {
                               },
                     },
                     nahmiiCombined: Immutable.Map {
+                              loading: false,
+                              error: null,
+                              assets: Immutable.List [
+                                        Immutable.Map {
+                                                  currency: "0x0000000000000000000000000000000000000000",
+                                                  balance: "0.2",
+                                                  symbol: "ETH",
+                                                  value: Immutable.Map {
+                                                            eth: "0.2",
+                                                            btc: "0.002",
+                                                            usd: "82.4",
+                                                  },
+                                        },
+                                        Immutable.Map {
+                                                  currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                  balance: "0.13",
+                                                  symbol: "BOKKY",
+                                                  value: Immutable.Map {
+                                                            eth: "0.013",
+                                                            btc: "0.00013",
+                                                            usd: "0.13",
+                                                  },
+                                        },
+                              ],
+                              total: Immutable.Map {
+                                        eth: "0.213",
+                                        btc: "0.00213",
+                                        usd: "82.53",
+                              },
+                    },
+                    nahmiiActive: Immutable.Map {
                               loading: false,
                               error: null,
                               assets: Immutable.List [
@@ -1529,6 +1622,37 @@ ShallowWrapper {
                                                             usd: "82.53",
                                                   },
                                         },
+                                        nahmiiActive: Immutable.Map {
+                                                  loading: false,
+                                                  error: null,
+                                                  assets: Immutable.List [
+                                                            Immutable.Map {
+                                                                      currency: "0x0000000000000000000000000000000000000000",
+                                                                      balance: "0.2",
+                                                                      symbol: "ETH",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.2",
+                                                                                btc: "0.002",
+                                                                                usd: "82.4",
+                                                                      },
+                                                            },
+                                                            Immutable.Map {
+                                                                      currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                      balance: "0.13",
+                                                                      symbol: "BOKKY",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.013",
+                                                                                btc: "0.00013",
+                                                                                usd: "0.13",
+                                                                      },
+                                                            },
+                                                  ],
+                                                  total: Immutable.Map {
+                                                            eth: "0.213",
+                                                            btc: "0.00213",
+                                                            usd: "82.53",
+                                                  },
+                                        },
                                         combined: Immutable.Map {
                                                   loading: false,
                                                   error: null,
@@ -1905,6 +2029,37 @@ ShallowWrapper {
                                     },
                         },
                         nahmiiCombined: Immutable.Map {
+                                    loading: false,
+                                    error: null,
+                                    assets: Immutable.List [
+                                                Immutable.Map {
+                                                            currency: "0x0000000000000000000000000000000000000000",
+                                                            balance: "0.2",
+                                                            symbol: "ETH",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.2",
+                                                                        btc: "0.002",
+                                                                        usd: "82.4",
+                                                            },
+                                                },
+                                                Immutable.Map {
+                                                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                            balance: "0.13",
+                                                            symbol: "BOKKY",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.013",
+                                                                        btc: "0.00013",
+                                                                        usd: "0.13",
+                                                            },
+                                                },
+                                    ],
+                                    total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                    },
+                        },
+                        nahmiiActive: Immutable.Map {
                                     loading: false,
                                     error: null,
                                     assets: Immutable.List [
@@ -2342,6 +2497,37 @@ ShallowWrapper {
                     },
                 },
                 nahmiiCombined: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
+                nahmiiActive: Immutable.Map {
                     loading: false,
                     error: null,
                     assets: Immutable.List [
@@ -2822,6 +3008,37 @@ ShallowWrapper {
                                                 usd: "82.53",
                                         },
                                 },
+                                nahmiiActive: Immutable.Map {
+                                        loading: false,
+                                        error: null,
+                                        assets: Immutable.List [
+                                                Immutable.Map {
+                                                        currency: "0x0000000000000000000000000000000000000000",
+                                                        balance: "0.2",
+                                                        symbol: "ETH",
+                                                        value: Immutable.Map {
+                                                                eth: "0.2",
+                                                                btc: "0.002",
+                                                                usd: "82.4",
+                                                        },
+                                                },
+                                                Immutable.Map {
+                                                        currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                        balance: "0.13",
+                                                        symbol: "BOKKY",
+                                                        value: Immutable.Map {
+                                                                eth: "0.013",
+                                                                btc: "0.00013",
+                                                                usd: "0.13",
+                                                        },
+                                                },
+                                        ],
+                                        total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                        },
+                                },
                                 combined: Immutable.Map {
                                         loading: false,
                                         error: null,
@@ -3201,6 +3418,37 @@ ShallowWrapper {
                               },
                     },
                     nahmiiCombined: Immutable.Map {
+                              loading: false,
+                              error: null,
+                              assets: Immutable.List [
+                                        Immutable.Map {
+                                                  currency: "0x0000000000000000000000000000000000000000",
+                                                  balance: "0.2",
+                                                  symbol: "ETH",
+                                                  value: Immutable.Map {
+                                                            eth: "0.2",
+                                                            btc: "0.002",
+                                                            usd: "82.4",
+                                                  },
+                                        },
+                                        Immutable.Map {
+                                                  currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                  balance: "0.13",
+                                                  symbol: "BOKKY",
+                                                  value: Immutable.Map {
+                                                            eth: "0.013",
+                                                            btc: "0.00013",
+                                                            usd: "0.13",
+                                                  },
+                                        },
+                              ],
+                              total: Immutable.Map {
+                                        eth: "0.213",
+                                        btc: "0.00213",
+                                        usd: "82.53",
+                              },
+                    },
+                    nahmiiActive: Immutable.Map {
                               loading: false,
                               error: null,
                               assets: Immutable.List [
@@ -3640,6 +3888,37 @@ ShallowWrapper {
                                                             usd: "82.53",
                                                   },
                                         },
+                                        nahmiiActive: Immutable.Map {
+                                                  loading: false,
+                                                  error: null,
+                                                  assets: Immutable.List [
+                                                            Immutable.Map {
+                                                                      currency: "0x0000000000000000000000000000000000000000",
+                                                                      balance: "0.2",
+                                                                      symbol: "ETH",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.2",
+                                                                                btc: "0.002",
+                                                                                usd: "82.4",
+                                                                      },
+                                                            },
+                                                            Immutable.Map {
+                                                                      currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                      balance: "0.13",
+                                                                      symbol: "BOKKY",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.013",
+                                                                                btc: "0.00013",
+                                                                                usd: "0.13",
+                                                                      },
+                                                            },
+                                                  ],
+                                                  total: Immutable.Map {
+                                                            eth: "0.213",
+                                                            btc: "0.00213",
+                                                            usd: "82.53",
+                                                  },
+                                        },
                                         combined: Immutable.Map {
                                                   loading: false,
                                                   error: null,
@@ -4019,6 +4298,37 @@ ShallowWrapper {
                                     },
                         },
                         nahmiiCombined: Immutable.Map {
+                                    loading: false,
+                                    error: null,
+                                    assets: Immutable.List [
+                                                Immutable.Map {
+                                                            currency: "0x0000000000000000000000000000000000000000",
+                                                            balance: "0.2",
+                                                            symbol: "ETH",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.2",
+                                                                        btc: "0.002",
+                                                                        usd: "82.4",
+                                                            },
+                                                },
+                                                Immutable.Map {
+                                                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                            balance: "0.13",
+                                                            symbol: "BOKKY",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.013",
+                                                                        btc: "0.00013",
+                                                                        usd: "0.13",
+                                                            },
+                                                },
+                                    ],
+                                    total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                    },
+                        },
+                        nahmiiActive: Immutable.Map {
                                     loading: false,
                                     error: null,
                                     assets: Immutable.List [
@@ -4459,6 +4769,37 @@ ShallowWrapper {
                     },
                 },
                 nahmiiCombined: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
+                nahmiiActive: Immutable.Map {
                     loading: false,
                     error: null,
                     assets: Immutable.List [
@@ -4937,6 +5278,37 @@ ShallowWrapper {
                                                 usd: "82.53",
                                         },
                                 },
+                                nahmiiActive: Immutable.Map {
+                                        loading: false,
+                                        error: null,
+                                        assets: Immutable.List [
+                                                Immutable.Map {
+                                                        currency: "0x0000000000000000000000000000000000000000",
+                                                        balance: "0.2",
+                                                        symbol: "ETH",
+                                                        value: Immutable.Map {
+                                                                eth: "0.2",
+                                                                btc: "0.002",
+                                                                usd: "82.4",
+                                                        },
+                                                },
+                                                Immutable.Map {
+                                                        currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                        balance: "0.13",
+                                                        symbol: "BOKKY",
+                                                        value: Immutable.Map {
+                                                                eth: "0.013",
+                                                                btc: "0.00013",
+                                                                usd: "0.13",
+                                                        },
+                                                },
+                                        ],
+                                        total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                        },
+                                },
                                 combined: Immutable.Map {
                                         loading: false,
                                         error: null,
@@ -5314,6 +5686,37 @@ ShallowWrapper {
                               },
                     },
                     nahmiiCombined: Immutable.Map {
+                              loading: false,
+                              error: null,
+                              assets: Immutable.List [
+                                        Immutable.Map {
+                                                  currency: "0x0000000000000000000000000000000000000000",
+                                                  balance: "0.2",
+                                                  symbol: "ETH",
+                                                  value: Immutable.Map {
+                                                            eth: "0.2",
+                                                            btc: "0.002",
+                                                            usd: "82.4",
+                                                  },
+                                        },
+                                        Immutable.Map {
+                                                  currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                  balance: "0.13",
+                                                  symbol: "BOKKY",
+                                                  value: Immutable.Map {
+                                                            eth: "0.013",
+                                                            btc: "0.00013",
+                                                            usd: "0.13",
+                                                  },
+                                        },
+                              ],
+                              total: Immutable.Map {
+                                        eth: "0.213",
+                                        btc: "0.00213",
+                                        usd: "82.53",
+                              },
+                    },
+                    nahmiiActive: Immutable.Map {
                               loading: false,
                               error: null,
                               assets: Immutable.List [
@@ -5751,6 +6154,37 @@ ShallowWrapper {
                                                             usd: "82.53",
                                                   },
                                         },
+                                        nahmiiActive: Immutable.Map {
+                                                  loading: false,
+                                                  error: null,
+                                                  assets: Immutable.List [
+                                                            Immutable.Map {
+                                                                      currency: "0x0000000000000000000000000000000000000000",
+                                                                      balance: "0.2",
+                                                                      symbol: "ETH",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.2",
+                                                                                btc: "0.002",
+                                                                                usd: "82.4",
+                                                                      },
+                                                            },
+                                                            Immutable.Map {
+                                                                      currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                      balance: "0.13",
+                                                                      symbol: "BOKKY",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.013",
+                                                                                btc: "0.00013",
+                                                                                usd: "0.13",
+                                                                      },
+                                                            },
+                                                  ],
+                                                  total: Immutable.Map {
+                                                            eth: "0.213",
+                                                            btc: "0.00213",
+                                                            usd: "82.53",
+                                                  },
+                                        },
                                         combined: Immutable.Map {
                                                   loading: false,
                                                   error: null,
@@ -6128,6 +6562,37 @@ ShallowWrapper {
                                     },
                         },
                         nahmiiCombined: Immutable.Map {
+                                    loading: false,
+                                    error: null,
+                                    assets: Immutable.List [
+                                                Immutable.Map {
+                                                            currency: "0x0000000000000000000000000000000000000000",
+                                                            balance: "0.2",
+                                                            symbol: "ETH",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.2",
+                                                                        btc: "0.002",
+                                                                        usd: "82.4",
+                                                            },
+                                                },
+                                                Immutable.Map {
+                                                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                            balance: "0.13",
+                                                            symbol: "BOKKY",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.013",
+                                                                        btc: "0.00013",
+                                                                        usd: "0.13",
+                                                            },
+                                                },
+                                    ],
+                                    total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                    },
+                        },
+                        nahmiiActive: Immutable.Map {
                                     loading: false,
                                     error: null,
                                     assets: Immutable.List [
@@ -6596,6 +7061,37 @@ ShallowWrapper {
                         usd: "82.53",
                     },
                 },
+                nahmiiActive: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
                 combined: Immutable.Map {
                     loading: false,
                     error: null,
@@ -7043,6 +7539,37 @@ ShallowWrapper {
                                                 usd: "82.53",
                                         },
                                 },
+                                nahmiiActive: Immutable.Map {
+                                        loading: false,
+                                        error: null,
+                                        assets: Immutable.List [
+                                                Immutable.Map {
+                                                        currency: "0x0000000000000000000000000000000000000000",
+                                                        balance: "0.2",
+                                                        symbol: "ETH",
+                                                        value: Immutable.Map {
+                                                                eth: "0.2",
+                                                                btc: "0.002",
+                                                                usd: "82.4",
+                                                        },
+                                                },
+                                                Immutable.Map {
+                                                        currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                        balance: "0.13",
+                                                        symbol: "BOKKY",
+                                                        value: Immutable.Map {
+                                                                eth: "0.013",
+                                                                btc: "0.00013",
+                                                                usd: "0.13",
+                                                        },
+                                                },
+                                        ],
+                                        total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                        },
+                                },
                                 combined: Immutable.Map {
                                         loading: false,
                                         error: null,
@@ -7419,6 +7946,37 @@ ShallowWrapper {
                               },
                     },
                     nahmiiCombined: Immutable.Map {
+                              loading: false,
+                              error: null,
+                              assets: Immutable.List [
+                                        Immutable.Map {
+                                                  currency: "0x0000000000000000000000000000000000000000",
+                                                  balance: "0.2",
+                                                  symbol: "ETH",
+                                                  value: Immutable.Map {
+                                                            eth: "0.2",
+                                                            btc: "0.002",
+                                                            usd: "82.4",
+                                                  },
+                                        },
+                                        Immutable.Map {
+                                                  currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                  balance: "0.13",
+                                                  symbol: "BOKKY",
+                                                  value: Immutable.Map {
+                                                            eth: "0.013",
+                                                            btc: "0.00013",
+                                                            usd: "0.13",
+                                                  },
+                                        },
+                              ],
+                              total: Immutable.Map {
+                                        eth: "0.213",
+                                        btc: "0.00213",
+                                        usd: "82.53",
+                              },
+                    },
+                    nahmiiActive: Immutable.Map {
                               loading: false,
                               error: null,
                               assets: Immutable.List [
@@ -7855,6 +8413,37 @@ ShallowWrapper {
                                                             usd: "82.53",
                                                   },
                                         },
+                                        nahmiiActive: Immutable.Map {
+                                                  loading: false,
+                                                  error: null,
+                                                  assets: Immutable.List [
+                                                            Immutable.Map {
+                                                                      currency: "0x0000000000000000000000000000000000000000",
+                                                                      balance: "0.2",
+                                                                      symbol: "ETH",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.2",
+                                                                                btc: "0.002",
+                                                                                usd: "82.4",
+                                                                      },
+                                                            },
+                                                            Immutable.Map {
+                                                                      currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                      balance: "0.13",
+                                                                      symbol: "BOKKY",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.013",
+                                                                                btc: "0.00013",
+                                                                                usd: "0.13",
+                                                                      },
+                                                            },
+                                                  ],
+                                                  total: Immutable.Map {
+                                                            eth: "0.213",
+                                                            btc: "0.00213",
+                                                            usd: "82.53",
+                                                  },
+                                        },
                                         combined: Immutable.Map {
                                                   loading: false,
                                                   error: null,
@@ -8231,6 +8820,37 @@ ShallowWrapper {
                                     },
                         },
                         nahmiiCombined: Immutable.Map {
+                                    loading: false,
+                                    error: null,
+                                    assets: Immutable.List [
+                                                Immutable.Map {
+                                                            currency: "0x0000000000000000000000000000000000000000",
+                                                            balance: "0.2",
+                                                            symbol: "ETH",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.2",
+                                                                        btc: "0.002",
+                                                                        usd: "82.4",
+                                                            },
+                                                },
+                                                Immutable.Map {
+                                                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                            balance: "0.13",
+                                                            symbol: "BOKKY",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.013",
+                                                                        btc: "0.00013",
+                                                                        usd: "0.13",
+                                                            },
+                                                },
+                                    ],
+                                    total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                    },
+                        },
+                        nahmiiActive: Immutable.Map {
                                     loading: false,
                                     error: null,
                                     assets: Immutable.List [
@@ -8698,6 +9318,37 @@ ShallowWrapper {
                         usd: "82.53",
                     },
                 },
+                nahmiiActive: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
                 combined: Immutable.Map {
                     loading: false,
                     error: null,
@@ -9104,6 +9755,37 @@ ShallowWrapper {
                                                 usd: "82.53",
                                         },
                                 },
+                                nahmiiActive: Immutable.Map {
+                                        loading: false,
+                                        error: null,
+                                        assets: Immutable.List [
+                                                Immutable.Map {
+                                                        currency: "0x0000000000000000000000000000000000000000",
+                                                        balance: "0.2",
+                                                        symbol: "ETH",
+                                                        value: Immutable.Map {
+                                                                eth: "0.2",
+                                                                btc: "0.002",
+                                                                usd: "82.4",
+                                                        },
+                                                },
+                                                Immutable.Map {
+                                                        currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                        balance: "0.13",
+                                                        symbol: "BOKKY",
+                                                        value: Immutable.Map {
+                                                                eth: "0.013",
+                                                                btc: "0.00013",
+                                                                usd: "0.13",
+                                                        },
+                                                },
+                                        ],
+                                        total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                        },
+                                },
                                 combined: Immutable.Map {
                                         loading: false,
                                         error: null,
@@ -9438,6 +10120,37 @@ ShallowWrapper {
                               },
                     },
                     nahmiiCombined: Immutable.Map {
+                              loading: false,
+                              error: null,
+                              assets: Immutable.List [
+                                        Immutable.Map {
+                                                  currency: "0x0000000000000000000000000000000000000000",
+                                                  balance: "0.2",
+                                                  symbol: "ETH",
+                                                  value: Immutable.Map {
+                                                            eth: "0.2",
+                                                            btc: "0.002",
+                                                            usd: "82.4",
+                                                  },
+                                        },
+                                        Immutable.Map {
+                                                  currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                  balance: "0.13",
+                                                  symbol: "BOKKY",
+                                                  value: Immutable.Map {
+                                                            eth: "0.013",
+                                                            btc: "0.00013",
+                                                            usd: "0.13",
+                                                  },
+                                        },
+                              ],
+                              total: Immutable.Map {
+                                        eth: "0.213",
+                                        btc: "0.00213",
+                                        usd: "82.53",
+                              },
+                    },
+                    nahmiiActive: Immutable.Map {
                               loading: false,
                               error: null,
                               assets: Immutable.List [
@@ -9832,6 +10545,37 @@ ShallowWrapper {
                                                             usd: "82.53",
                                                   },
                                         },
+                                        nahmiiActive: Immutable.Map {
+                                                  loading: false,
+                                                  error: null,
+                                                  assets: Immutable.List [
+                                                            Immutable.Map {
+                                                                      currency: "0x0000000000000000000000000000000000000000",
+                                                                      balance: "0.2",
+                                                                      symbol: "ETH",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.2",
+                                                                                btc: "0.002",
+                                                                                usd: "82.4",
+                                                                      },
+                                                            },
+                                                            Immutable.Map {
+                                                                      currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                      balance: "0.13",
+                                                                      symbol: "BOKKY",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.013",
+                                                                                btc: "0.00013",
+                                                                                usd: "0.13",
+                                                                      },
+                                                            },
+                                                  ],
+                                                  total: Immutable.Map {
+                                                            eth: "0.213",
+                                                            btc: "0.00213",
+                                                            usd: "82.53",
+                                                  },
+                                        },
                                         combined: Immutable.Map {
                                                   loading: false,
                                                   error: null,
@@ -10166,6 +10910,37 @@ ShallowWrapper {
                                     },
                         },
                         nahmiiCombined: Immutable.Map {
+                                    loading: false,
+                                    error: null,
+                                    assets: Immutable.List [
+                                                Immutable.Map {
+                                                            currency: "0x0000000000000000000000000000000000000000",
+                                                            balance: "0.2",
+                                                            symbol: "ETH",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.2",
+                                                                        btc: "0.002",
+                                                                        usd: "82.4",
+                                                            },
+                                                },
+                                                Immutable.Map {
+                                                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                            balance: "0.13",
+                                                            symbol: "BOKKY",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.013",
+                                                                        btc: "0.00013",
+                                                                        usd: "0.13",
+                                                            },
+                                                },
+                                    ],
+                                    total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                    },
+                        },
+                        nahmiiActive: Immutable.Map {
                                     loading: false,
                                     error: null,
                                     assets: Immutable.List [
@@ -10561,6 +11336,37 @@ ShallowWrapper {
                     },
                 },
                 nahmiiCombined: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
+                nahmiiActive: Immutable.Map {
                     loading: false,
                     error: null,
                     assets: Immutable.List [
@@ -10997,6 +11803,37 @@ ShallowWrapper {
                                                 usd: "82.53",
                                         },
                                 },
+                                nahmiiActive: Immutable.Map {
+                                        loading: false,
+                                        error: null,
+                                        assets: Immutable.List [
+                                                Immutable.Map {
+                                                        currency: "0x0000000000000000000000000000000000000000",
+                                                        balance: "0.2",
+                                                        symbol: "ETH",
+                                                        value: Immutable.Map {
+                                                                eth: "0.2",
+                                                                btc: "0.002",
+                                                                usd: "82.4",
+                                                        },
+                                                },
+                                                Immutable.Map {
+                                                        currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                        balance: "0.13",
+                                                        symbol: "BOKKY",
+                                                        value: Immutable.Map {
+                                                                eth: "0.013",
+                                                                btc: "0.00013",
+                                                                usd: "0.13",
+                                                        },
+                                                },
+                                        ],
+                                        total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                        },
+                                },
                                 combined: Immutable.Map {
                                         loading: false,
                                         error: null,
@@ -11331,6 +12168,37 @@ ShallowWrapper {
                               },
                     },
                     nahmiiCombined: Immutable.Map {
+                              loading: false,
+                              error: null,
+                              assets: Immutable.List [
+                                        Immutable.Map {
+                                                  currency: "0x0000000000000000000000000000000000000000",
+                                                  balance: "0.2",
+                                                  symbol: "ETH",
+                                                  value: Immutable.Map {
+                                                            eth: "0.2",
+                                                            btc: "0.002",
+                                                            usd: "82.4",
+                                                  },
+                                        },
+                                        Immutable.Map {
+                                                  currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                  balance: "0.13",
+                                                  symbol: "BOKKY",
+                                                  value: Immutable.Map {
+                                                            eth: "0.013",
+                                                            btc: "0.00013",
+                                                            usd: "0.13",
+                                                  },
+                                        },
+                              ],
+                              total: Immutable.Map {
+                                        eth: "0.213",
+                                        btc: "0.00213",
+                                        usd: "82.53",
+                              },
+                    },
+                    nahmiiActive: Immutable.Map {
                               loading: false,
                               error: null,
                               assets: Immutable.List [
@@ -11725,6 +12593,37 @@ ShallowWrapper {
                                                             usd: "82.53",
                                                   },
                                         },
+                                        nahmiiActive: Immutable.Map {
+                                                  loading: false,
+                                                  error: null,
+                                                  assets: Immutable.List [
+                                                            Immutable.Map {
+                                                                      currency: "0x0000000000000000000000000000000000000000",
+                                                                      balance: "0.2",
+                                                                      symbol: "ETH",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.2",
+                                                                                btc: "0.002",
+                                                                                usd: "82.4",
+                                                                      },
+                                                            },
+                                                            Immutable.Map {
+                                                                      currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                      balance: "0.13",
+                                                                      symbol: "BOKKY",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.013",
+                                                                                btc: "0.00013",
+                                                                                usd: "0.13",
+                                                                      },
+                                                            },
+                                                  ],
+                                                  total: Immutable.Map {
+                                                            eth: "0.213",
+                                                            btc: "0.00213",
+                                                            usd: "82.53",
+                                                  },
+                                        },
                                         combined: Immutable.Map {
                                                   loading: false,
                                                   error: null,
@@ -12059,6 +12958,37 @@ ShallowWrapper {
                                     },
                         },
                         nahmiiCombined: Immutable.Map {
+                                    loading: false,
+                                    error: null,
+                                    assets: Immutable.List [
+                                                Immutable.Map {
+                                                            currency: "0x0000000000000000000000000000000000000000",
+                                                            balance: "0.2",
+                                                            symbol: "ETH",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.2",
+                                                                        btc: "0.002",
+                                                                        usd: "82.4",
+                                                            },
+                                                },
+                                                Immutable.Map {
+                                                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                            balance: "0.13",
+                                                            symbol: "BOKKY",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.013",
+                                                                        btc: "0.00013",
+                                                                        usd: "0.13",
+                                                            },
+                                                },
+                                    ],
+                                    total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                    },
+                        },
+                        nahmiiActive: Immutable.Map {
                                     loading: false,
                                     error: null,
                                     assets: Immutable.List [
@@ -12454,6 +13384,37 @@ ShallowWrapper {
                     },
                 },
                 nahmiiCombined: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
+                nahmiiActive: Immutable.Map {
                     loading: false,
                     error: null,
                     assets: Immutable.List [
@@ -12895,6 +13856,37 @@ ShallowWrapper {
                                                 usd: "82.53",
                                         },
                                 },
+                                nahmiiActive: Immutable.Map {
+                                        loading: false,
+                                        error: null,
+                                        assets: Immutable.List [
+                                                Immutable.Map {
+                                                        currency: "0x0000000000000000000000000000000000000000",
+                                                        balance: "0.2",
+                                                        symbol: "ETH",
+                                                        value: Immutable.Map {
+                                                                eth: "0.2",
+                                                                btc: "0.002",
+                                                                usd: "82.4",
+                                                        },
+                                                },
+                                                Immutable.Map {
+                                                        currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                        balance: "0.13",
+                                                        symbol: "BOKKY",
+                                                        value: Immutable.Map {
+                                                                eth: "0.013",
+                                                                btc: "0.00013",
+                                                                usd: "0.13",
+                                                        },
+                                                },
+                                        ],
+                                        total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                        },
+                                },
                                 combined: Immutable.Map {
                                         loading: false,
                                         error: null,
@@ -13235,6 +14227,37 @@ ShallowWrapper {
                               },
                     },
                     nahmiiCombined: Immutable.Map {
+                              loading: false,
+                              error: null,
+                              assets: Immutable.List [
+                                        Immutable.Map {
+                                                  currency: "0x0000000000000000000000000000000000000000",
+                                                  balance: "0.2",
+                                                  symbol: "ETH",
+                                                  value: Immutable.Map {
+                                                            eth: "0.2",
+                                                            btc: "0.002",
+                                                            usd: "82.4",
+                                                  },
+                                        },
+                                        Immutable.Map {
+                                                  currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                  balance: "0.13",
+                                                  symbol: "BOKKY",
+                                                  value: Immutable.Map {
+                                                            eth: "0.013",
+                                                            btc: "0.00013",
+                                                            usd: "0.13",
+                                                  },
+                                        },
+                              ],
+                              total: Immutable.Map {
+                                        eth: "0.213",
+                                        btc: "0.00213",
+                                        usd: "82.53",
+                              },
+                    },
+                    nahmiiActive: Immutable.Map {
                               loading: false,
                               error: null,
                               assets: Immutable.List [
@@ -13635,6 +14658,37 @@ ShallowWrapper {
                                                             usd: "82.53",
                                                   },
                                         },
+                                        nahmiiActive: Immutable.Map {
+                                                  loading: false,
+                                                  error: null,
+                                                  assets: Immutable.List [
+                                                            Immutable.Map {
+                                                                      currency: "0x0000000000000000000000000000000000000000",
+                                                                      balance: "0.2",
+                                                                      symbol: "ETH",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.2",
+                                                                                btc: "0.002",
+                                                                                usd: "82.4",
+                                                                      },
+                                                            },
+                                                            Immutable.Map {
+                                                                      currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                      balance: "0.13",
+                                                                      symbol: "BOKKY",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.013",
+                                                                                btc: "0.00013",
+                                                                                usd: "0.13",
+                                                                      },
+                                                            },
+                                                  ],
+                                                  total: Immutable.Map {
+                                                            eth: "0.213",
+                                                            btc: "0.00213",
+                                                            usd: "82.53",
+                                                  },
+                                        },
                                         combined: Immutable.Map {
                                                   loading: false,
                                                   error: null,
@@ -13975,6 +15029,37 @@ ShallowWrapper {
                                     },
                         },
                         nahmiiCombined: Immutable.Map {
+                                    loading: false,
+                                    error: null,
+                                    assets: Immutable.List [
+                                                Immutable.Map {
+                                                            currency: "0x0000000000000000000000000000000000000000",
+                                                            balance: "0.2",
+                                                            symbol: "ETH",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.2",
+                                                                        btc: "0.002",
+                                                                        usd: "82.4",
+                                                            },
+                                                },
+                                                Immutable.Map {
+                                                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                            balance: "0.13",
+                                                            symbol: "BOKKY",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.013",
+                                                                        btc: "0.00013",
+                                                                        usd: "0.13",
+                                                            },
+                                                },
+                                    ],
+                                    total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                    },
+                        },
+                        nahmiiActive: Immutable.Map {
                                     loading: false,
                                     error: null,
                                     assets: Immutable.List [
@@ -14406,6 +15491,37 @@ ShallowWrapper {
                         usd: "82.53",
                     },
                 },
+                nahmiiActive: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
                 combined: Immutable.Map {
                     loading: false,
                     error: null,
@@ -14817,6 +15933,37 @@ ShallowWrapper {
                                                 usd: "82.53",
                                         },
                                 },
+                                nahmiiActive: Immutable.Map {
+                                        loading: false,
+                                        error: null,
+                                        assets: Immutable.List [
+                                                Immutable.Map {
+                                                        currency: "0x0000000000000000000000000000000000000000",
+                                                        balance: "0.2",
+                                                        symbol: "ETH",
+                                                        value: Immutable.Map {
+                                                                eth: "0.2",
+                                                                btc: "0.002",
+                                                                usd: "82.4",
+                                                        },
+                                                },
+                                                Immutable.Map {
+                                                        currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                        balance: "0.13",
+                                                        symbol: "BOKKY",
+                                                        value: Immutable.Map {
+                                                                eth: "0.013",
+                                                                btc: "0.00013",
+                                                                usd: "0.13",
+                                                        },
+                                                },
+                                        ],
+                                        total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                        },
+                                },
                                 combined: Immutable.Map {
                                         loading: false,
                                         error: null,
@@ -15157,6 +16304,37 @@ ShallowWrapper {
                               },
                     },
                     nahmiiCombined: Immutable.Map {
+                              loading: false,
+                              error: null,
+                              assets: Immutable.List [
+                                        Immutable.Map {
+                                                  currency: "0x0000000000000000000000000000000000000000",
+                                                  balance: "0.2",
+                                                  symbol: "ETH",
+                                                  value: Immutable.Map {
+                                                            eth: "0.2",
+                                                            btc: "0.002",
+                                                            usd: "82.4",
+                                                  },
+                                        },
+                                        Immutable.Map {
+                                                  currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                  balance: "0.13",
+                                                  symbol: "BOKKY",
+                                                  value: Immutable.Map {
+                                                            eth: "0.013",
+                                                            btc: "0.00013",
+                                                            usd: "0.13",
+                                                  },
+                                        },
+                              ],
+                              total: Immutable.Map {
+                                        eth: "0.213",
+                                        btc: "0.00213",
+                                        usd: "82.53",
+                              },
+                    },
+                    nahmiiActive: Immutable.Map {
                               loading: false,
                               error: null,
                               assets: Immutable.List [
@@ -15557,6 +16735,37 @@ ShallowWrapper {
                                                             usd: "82.53",
                                                   },
                                         },
+                                        nahmiiActive: Immutable.Map {
+                                                  loading: false,
+                                                  error: null,
+                                                  assets: Immutable.List [
+                                                            Immutable.Map {
+                                                                      currency: "0x0000000000000000000000000000000000000000",
+                                                                      balance: "0.2",
+                                                                      symbol: "ETH",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.2",
+                                                                                btc: "0.002",
+                                                                                usd: "82.4",
+                                                                      },
+                                                            },
+                                                            Immutable.Map {
+                                                                      currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                      balance: "0.13",
+                                                                      symbol: "BOKKY",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.013",
+                                                                                btc: "0.00013",
+                                                                                usd: "0.13",
+                                                                      },
+                                                            },
+                                                  ],
+                                                  total: Immutable.Map {
+                                                            eth: "0.213",
+                                                            btc: "0.00213",
+                                                            usd: "82.53",
+                                                  },
+                                        },
                                         combined: Immutable.Map {
                                                   loading: false,
                                                   error: null,
@@ -15897,6 +17106,37 @@ ShallowWrapper {
                                     },
                         },
                         nahmiiCombined: Immutable.Map {
+                                    loading: false,
+                                    error: null,
+                                    assets: Immutable.List [
+                                                Immutable.Map {
+                                                            currency: "0x0000000000000000000000000000000000000000",
+                                                            balance: "0.2",
+                                                            symbol: "ETH",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.2",
+                                                                        btc: "0.002",
+                                                                        usd: "82.4",
+                                                            },
+                                                },
+                                                Immutable.Map {
+                                                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                            balance: "0.13",
+                                                            symbol: "BOKKY",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.013",
+                                                                        btc: "0.00013",
+                                                                        usd: "0.13",
+                                                            },
+                                                },
+                                    ],
+                                    total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                    },
+                        },
+                        nahmiiActive: Immutable.Map {
                                     loading: false,
                                     error: null,
                                     assets: Immutable.List [
@@ -16298,6 +17538,37 @@ ShallowWrapper {
                     },
                 },
                 nahmiiCombined: Immutable.Map {
+                    loading: false,
+                    error: null,
+                    assets: Immutable.List [
+                        Immutable.Map {
+                            currency: "0x0000000000000000000000000000000000000000",
+                            balance: "0.2",
+                            symbol: "ETH",
+                            value: Immutable.Map {
+                                eth: "0.2",
+                                btc: "0.002",
+                                usd: "82.4",
+                            },
+                        },
+                        Immutable.Map {
+                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            balance: "0.13",
+                            symbol: "BOKKY",
+                            value: Immutable.Map {
+                                eth: "0.013",
+                                btc: "0.00013",
+                                usd: "0.13",
+                            },
+                        },
+                    ],
+                    total: Immutable.Map {
+                        eth: "0.213",
+                        btc: "0.00213",
+                        usd: "82.53",
+                    },
+                },
+                nahmiiActive: Immutable.Map {
                     loading: false,
                     error: null,
                     assets: Immutable.List [
@@ -16775,6 +18046,37 @@ ShallowWrapper {
                                                 usd: "82.53",
                                         },
                                 },
+                                nahmiiActive: Immutable.Map {
+                                        loading: false,
+                                        error: null,
+                                        assets: Immutable.List [
+                                                Immutable.Map {
+                                                        currency: "0x0000000000000000000000000000000000000000",
+                                                        balance: "0.2",
+                                                        symbol: "ETH",
+                                                        value: Immutable.Map {
+                                                                eth: "0.2",
+                                                                btc: "0.002",
+                                                                usd: "82.4",
+                                                        },
+                                                },
+                                                Immutable.Map {
+                                                        currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                        balance: "0.13",
+                                                        symbol: "BOKKY",
+                                                        value: Immutable.Map {
+                                                                eth: "0.013",
+                                                                btc: "0.00013",
+                                                                usd: "0.13",
+                                                        },
+                                                },
+                                        ],
+                                        total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                        },
+                                },
                                 combined: Immutable.Map {
                                         loading: false,
                                         error: null,
@@ -17151,6 +18453,37 @@ ShallowWrapper {
                               },
                     },
                     nahmiiCombined: Immutable.Map {
+                              loading: false,
+                              error: null,
+                              assets: Immutable.List [
+                                        Immutable.Map {
+                                                  currency: "0x0000000000000000000000000000000000000000",
+                                                  balance: "0.2",
+                                                  symbol: "ETH",
+                                                  value: Immutable.Map {
+                                                            eth: "0.2",
+                                                            btc: "0.002",
+                                                            usd: "82.4",
+                                                  },
+                                        },
+                                        Immutable.Map {
+                                                  currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                  balance: "0.13",
+                                                  symbol: "BOKKY",
+                                                  value: Immutable.Map {
+                                                            eth: "0.013",
+                                                            btc: "0.00013",
+                                                            usd: "0.13",
+                                                  },
+                                        },
+                              ],
+                              total: Immutable.Map {
+                                        eth: "0.213",
+                                        btc: "0.00213",
+                                        usd: "82.53",
+                              },
+                    },
+                    nahmiiActive: Immutable.Map {
                               loading: false,
                               error: null,
                               assets: Immutable.List [
@@ -17587,6 +18920,37 @@ ShallowWrapper {
                                                             usd: "82.53",
                                                   },
                                         },
+                                        nahmiiActive: Immutable.Map {
+                                                  loading: false,
+                                                  error: null,
+                                                  assets: Immutable.List [
+                                                            Immutable.Map {
+                                                                      currency: "0x0000000000000000000000000000000000000000",
+                                                                      balance: "0.2",
+                                                                      symbol: "ETH",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.2",
+                                                                                btc: "0.002",
+                                                                                usd: "82.4",
+                                                                      },
+                                                            },
+                                                            Immutable.Map {
+                                                                      currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                      balance: "0.13",
+                                                                      symbol: "BOKKY",
+                                                                      value: Immutable.Map {
+                                                                                eth: "0.013",
+                                                                                btc: "0.00013",
+                                                                                usd: "0.13",
+                                                                      },
+                                                            },
+                                                  ],
+                                                  total: Immutable.Map {
+                                                            eth: "0.213",
+                                                            btc: "0.00213",
+                                                            usd: "82.53",
+                                                  },
+                                        },
                                         combined: Immutable.Map {
                                                   loading: false,
                                                   error: null,
@@ -17963,6 +19327,37 @@ ShallowWrapper {
                                     },
                         },
                         nahmiiCombined: Immutable.Map {
+                                    loading: false,
+                                    error: null,
+                                    assets: Immutable.List [
+                                                Immutable.Map {
+                                                            currency: "0x0000000000000000000000000000000000000000",
+                                                            balance: "0.2",
+                                                            symbol: "ETH",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.2",
+                                                                        btc: "0.002",
+                                                                        usd: "82.4",
+                                                            },
+                                                },
+                                                Immutable.Map {
+                                                            currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                            balance: "0.13",
+                                                            symbol: "BOKKY",
+                                                            value: Immutable.Map {
+                                                                        eth: "0.013",
+                                                                        btc: "0.00013",
+                                                                        usd: "0.13",
+                                                            },
+                                                },
+                                    ],
+                                    total: Immutable.Map {
+                                                eth: "0.213",
+                                                btc: "0.00213",
+                                                usd: "82.53",
+                                    },
+                        },
+                        nahmiiActive: Immutable.Map {
                                     loading: false,
                                     error: null,
                                     assets: Immutable.List [

--- a/src/containers/WalletsOverview/index.js
+++ b/src/containers/WalletsOverview/index.js
@@ -57,7 +57,7 @@ import { WalletCardsCol } from './style';
 const SortableWallet = SortableElement((props) => {
   const connected = isConnected(props.wallet, props.ledgerNanoSInfo.toJS(), props.trezorInfo.toJS());
   const baseLayerBalance = props.wallet.balances.baseLayer;
-  const nahmiiBalance = props.wallet.balances.nahmiiCombined;
+  const nahmiiBalance = props.wallet.balances.nahmiiActive;
   return (
     <WalletCardsCol
       span={10}

--- a/src/containers/WalletsOverview/tests/__snapshots__/index.test.js.snap
+++ b/src/containers/WalletsOverview/tests/__snapshots__/index.test.js.snap
@@ -154,6 +154,27 @@ ShallowWrapper {
                     usd: "0",
                 },
             },
+            nahmiiActive: Immutable.Map {
+                assets: Immutable.Map {
+                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                        value: Immutable.Map {
+                            usd: "82.4",
+                        },
+                        amount: "0.2",
+                    },
+                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                        value: Immutable.Map {
+                            usd: "0.13",
+                        },
+                        amount: "0.13",
+                    },
+                },
+                loading: false,
+                error: null,
+                total: Immutable.Map {
+                    usd: "82.53",
+                },
+            },
             nahmiiCombined: Immutable.Map {
                 assets: Immutable.Map {
                     0x0000000000000000000000000000000000000000: Immutable.Map {
@@ -373,6 +394,37 @@ ShallowWrapper {
                             usd: "82.53",
                         },
                     },
+                    nahmiiActive: Immutable.Map {
+                        loading: false,
+                        error: null,
+                        assets: Immutable.List [
+                            Immutable.Map {
+                                currency: "0x0000000000000000000000000000000000000000",
+                                balance: "0.2",
+                                symbol: "ETH",
+                                value: Immutable.Map {
+                                    eth: "0.2",
+                                    btc: "0.002",
+                                    usd: "82.4",
+                                },
+                            },
+                            Immutable.Map {
+                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                balance: "0.13",
+                                symbol: "BOKKY",
+                                value: Immutable.Map {
+                                    eth: "0.013",
+                                    btc: "0.00013",
+                                    usd: "0.13",
+                                },
+                            },
+                        ],
+                        total: Immutable.Map {
+                            eth: "0.213",
+                            btc: "0.00213",
+                            usd: "82.53",
+                        },
+                    },
                     combined: Immutable.Map {
                         loading: false,
                         error: null,
@@ -467,6 +519,17 @@ ShallowWrapper {
                             usd: "0",
                         },
                     },
+                    nahmiiActive: Immutable.Map {
+                        loading: false,
+                        error: true,
+                        assets: Immutable.List [
+                        ],
+                        total: Immutable.Map {
+                            eth: "0",
+                            btc: "0",
+                            usd: "0",
+                        },
+                    },
                     combined: Immutable.Map {
                         loading: false,
                         error: true,
@@ -547,6 +610,17 @@ ShallowWrapper {
                             usd: "0",
                         },
                     },
+                    nahmiiActive: Immutable.Map {
+                        loading: true,
+                        error: null,
+                        assets: Immutable.List [
+                        ],
+                        total: Immutable.Map {
+                            eth: "0",
+                            btc: "0",
+                            usd: "0",
+                        },
+                    },
                     combined: Immutable.Map {
                         loading: true,
                         error: null,
@@ -612,6 +686,17 @@ ShallowWrapper {
                         },
                     },
                     nahmiiCombined: Immutable.Map {
+                        loading: false,
+                        error: null,
+                        assets: Immutable.List [
+                        ],
+                        total: Immutable.Map {
+                            eth: "0",
+                            btc: "0",
+                            usd: "0",
+                        },
+                    },
+                    nahmiiActive: Immutable.Map {
                         loading: false,
                         error: null,
                         assets: Immutable.List [
@@ -814,6 +899,37 @@ ShallowWrapper {
                                                 "usd": "164.492044000001231288",
                                               },
                                             },
+                                            "nahmiiActive": Object {
+                                              "assets": Array [
+                                                Object {
+                                                  "balance": "0.2",
+                                                  "currency": "0x0000000000000000000000000000000000000000",
+                                                  "symbol": "ETH",
+                                                  "value": Object {
+                                                    "btc": "0.002",
+                                                    "eth": "0.2",
+                                                    "usd": "82.4",
+                                                  },
+                                                },
+                                                Object {
+                                                  "balance": "0.13",
+                                                  "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                  "symbol": "BOKKY",
+                                                  "value": Object {
+                                                    "btc": "0.00013",
+                                                    "eth": "0.013",
+                                                    "usd": "0.13",
+                                                  },
+                                                },
+                                              ],
+                                              "error": null,
+                                              "loading": false,
+                                              "total": Object {
+                                                "btc": "0.00213",
+                                                "eth": "0.213",
+                                                "usd": "82.53",
+                                              },
+                                            },
                                             "nahmiiAvailable": Object {
                                               "assets": Array [
                                                 Object {
@@ -936,6 +1052,16 @@ ShallowWrapper {
                                                 "usd": "0",
                                               },
                                             },
+                                            "nahmiiActive": Object {
+                                              "assets": Array [],
+                                              "error": true,
+                                              "loading": false,
+                                              "total": Object {
+                                                "btc": "0",
+                                                "eth": "0",
+                                                "usd": "0",
+                                              },
+                                            },
                                             "nahmiiAvailable": Object {
                                               "assets": Array [],
                                               "error": true,
@@ -995,6 +1121,16 @@ ShallowWrapper {
                                               },
                                             },
                                             "combined": Object {
+                                              "assets": Array [],
+                                              "error": null,
+                                              "loading": true,
+                                              "total": Object {
+                                                "btc": "0",
+                                                "eth": "0",
+                                                "usd": "0",
+                                              },
+                                            },
+                                            "nahmiiActive": Object {
                                               "assets": Array [],
                                               "error": null,
                                               "loading": true,
@@ -1072,6 +1208,16 @@ ShallowWrapper {
                                               "assets": Array [],
                                               "error": null,
                                               "loading": true,
+                                              "total": Object {
+                                                "btc": "0",
+                                                "eth": "0",
+                                                "usd": "0",
+                                              },
+                                            },
+                                            "nahmiiActive": Object {
+                                              "assets": Array [],
+                                              "error": null,
+                                              "loading": false,
                                               "total": Object {
                                                 "btc": "0",
                                                 "eth": "0",
@@ -1298,6 +1444,37 @@ ShallowWrapper {
                                                         "usd": "164.492044000001231288",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [
+                                                        Object {
+                                                          "balance": "0.2",
+                                                          "currency": "0x0000000000000000000000000000000000000000",
+                                                          "symbol": "ETH",
+                                                          "value": Object {
+                                                            "btc": "0.002",
+                                                            "eth": "0.2",
+                                                            "usd": "82.4",
+                                                          },
+                                                        },
+                                                        Object {
+                                                          "balance": "0.13",
+                                                          "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                          "symbol": "BOKKY",
+                                                          "value": Object {
+                                                            "btc": "0.00013",
+                                                            "eth": "0.013",
+                                                            "usd": "0.13",
+                                                          },
+                                                        },
+                                                      ],
+                                                      "error": null,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0.00213",
+                                                        "eth": "0.213",
+                                                        "usd": "82.53",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [
                                                         Object {
@@ -1420,6 +1597,16 @@ ShallowWrapper {
                                                         "usd": "0",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": true,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [],
                                                       "error": true,
@@ -1479,6 +1666,16 @@ ShallowWrapper {
                                                       },
                                                     },
                                                     "combined": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
@@ -1556,6 +1753,16 @@ ShallowWrapper {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": false,
                                                       "total": Object {
                                                         "btc": "0",
                                                         "eth": "0",
@@ -1782,6 +1989,37 @@ ShallowWrapper {
                                                         "usd": "164.492044000001231288",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [
+                                                        Object {
+                                                          "balance": "0.2",
+                                                          "currency": "0x0000000000000000000000000000000000000000",
+                                                          "symbol": "ETH",
+                                                          "value": Object {
+                                                            "btc": "0.002",
+                                                            "eth": "0.2",
+                                                            "usd": "82.4",
+                                                          },
+                                                        },
+                                                        Object {
+                                                          "balance": "0.13",
+                                                          "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                          "symbol": "BOKKY",
+                                                          "value": Object {
+                                                            "btc": "0.00013",
+                                                            "eth": "0.013",
+                                                            "usd": "0.13",
+                                                          },
+                                                        },
+                                                      ],
+                                                      "error": null,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0.00213",
+                                                        "eth": "0.213",
+                                                        "usd": "82.53",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [
                                                         Object {
@@ -1904,6 +2142,16 @@ ShallowWrapper {
                                                         "usd": "0",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": true,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [],
                                                       "error": true,
@@ -1963,6 +2211,16 @@ ShallowWrapper {
                                                       },
                                                     },
                                                     "combined": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
@@ -2040,6 +2298,16 @@ ShallowWrapper {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": false,
                                                       "total": Object {
                                                         "btc": "0",
                                                         "eth": "0",
@@ -2258,6 +2526,37 @@ ShallowWrapper {
                           "usd": "164.492044000001231288",
                         },
                       },
+                      "nahmiiActive": Object {
+                        "assets": Array [
+                          Object {
+                            "balance": "0.2",
+                            "currency": "0x0000000000000000000000000000000000000000",
+                            "symbol": "ETH",
+                            "value": Object {
+                              "btc": "0.002",
+                              "eth": "0.2",
+                              "usd": "82.4",
+                            },
+                          },
+                          Object {
+                            "balance": "0.13",
+                            "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            "symbol": "BOKKY",
+                            "value": Object {
+                              "btc": "0.00013",
+                              "eth": "0.013",
+                              "usd": "0.13",
+                            },
+                          },
+                        ],
+                        "error": null,
+                        "loading": false,
+                        "total": Object {
+                          "btc": "0.00213",
+                          "eth": "0.213",
+                          "usd": "82.53",
+                        },
+                      },
                       "nahmiiAvailable": Object {
                         "assets": Array [
                           Object {
@@ -2380,6 +2679,16 @@ ShallowWrapper {
                           "usd": "0",
                         },
                       },
+                      "nahmiiActive": Object {
+                        "assets": Array [],
+                        "error": true,
+                        "loading": false,
+                        "total": Object {
+                          "btc": "0",
+                          "eth": "0",
+                          "usd": "0",
+                        },
+                      },
                       "nahmiiAvailable": Object {
                         "assets": Array [],
                         "error": true,
@@ -2439,6 +2748,16 @@ ShallowWrapper {
                         },
                       },
                       "combined": Object {
+                        "assets": Array [],
+                        "error": null,
+                        "loading": true,
+                        "total": Object {
+                          "btc": "0",
+                          "eth": "0",
+                          "usd": "0",
+                        },
+                      },
+                      "nahmiiActive": Object {
                         "assets": Array [],
                         "error": null,
                         "loading": true,
@@ -2516,6 +2835,16 @@ ShallowWrapper {
                         "assets": Array [],
                         "error": null,
                         "loading": true,
+                        "total": Object {
+                          "btc": "0",
+                          "eth": "0",
+                          "usd": "0",
+                        },
+                      },
+                      "nahmiiActive": Object {
+                        "assets": Array [],
+                        "error": null,
+                        "loading": false,
                         "total": Object {
                           "btc": "0",
                           "eth": "0",
@@ -2766,6 +3095,37 @@ ShallowWrapper {
                                                           "usd": "164.492044000001231288",
                                                         },
                                                       },
+                                                      "nahmiiActive": Object {
+                                                        "assets": Array [
+                                                          Object {
+                                                            "balance": "0.2",
+                                                            "currency": "0x0000000000000000000000000000000000000000",
+                                                            "symbol": "ETH",
+                                                            "value": Object {
+                                                              "btc": "0.002",
+                                                              "eth": "0.2",
+                                                              "usd": "82.4",
+                                                            },
+                                                          },
+                                                          Object {
+                                                            "balance": "0.13",
+                                                            "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                            "symbol": "BOKKY",
+                                                            "value": Object {
+                                                              "btc": "0.00013",
+                                                              "eth": "0.013",
+                                                              "usd": "0.13",
+                                                            },
+                                                          },
+                                                        ],
+                                                        "error": null,
+                                                        "loading": false,
+                                                        "total": Object {
+                                                          "btc": "0.00213",
+                                                          "eth": "0.213",
+                                                          "usd": "82.53",
+                                                        },
+                                                      },
                                                       "nahmiiAvailable": Object {
                                                         "assets": Array [
                                                           Object {
@@ -2888,6 +3248,16 @@ ShallowWrapper {
                                                           "usd": "0",
                                                         },
                                                       },
+                                                      "nahmiiActive": Object {
+                                                        "assets": Array [],
+                                                        "error": true,
+                                                        "loading": false,
+                                                        "total": Object {
+                                                          "btc": "0",
+                                                          "eth": "0",
+                                                          "usd": "0",
+                                                        },
+                                                      },
                                                       "nahmiiAvailable": Object {
                                                         "assets": Array [],
                                                         "error": true,
@@ -2947,6 +3317,16 @@ ShallowWrapper {
                                                         },
                                                       },
                                                       "combined": Object {
+                                                        "assets": Array [],
+                                                        "error": null,
+                                                        "loading": true,
+                                                        "total": Object {
+                                                          "btc": "0",
+                                                          "eth": "0",
+                                                          "usd": "0",
+                                                        },
+                                                      },
+                                                      "nahmiiActive": Object {
                                                         "assets": Array [],
                                                         "error": null,
                                                         "loading": true,
@@ -3024,6 +3404,16 @@ ShallowWrapper {
                                                         "assets": Array [],
                                                         "error": null,
                                                         "loading": true,
+                                                        "total": Object {
+                                                          "btc": "0",
+                                                          "eth": "0",
+                                                          "usd": "0",
+                                                        },
+                                                      },
+                                                      "nahmiiActive": Object {
+                                                        "assets": Array [],
+                                                        "error": null,
+                                                        "loading": false,
                                                         "total": Object {
                                                           "btc": "0",
                                                           "eth": "0",
@@ -3250,6 +3640,37 @@ ShallowWrapper {
                                                                 "usd": "164.492044000001231288",
                                                               },
                                                             },
+                                                            "nahmiiActive": Object {
+                                                              "assets": Array [
+                                                                Object {
+                                                                  "balance": "0.2",
+                                                                  "currency": "0x0000000000000000000000000000000000000000",
+                                                                  "symbol": "ETH",
+                                                                  "value": Object {
+                                                                    "btc": "0.002",
+                                                                    "eth": "0.2",
+                                                                    "usd": "82.4",
+                                                                  },
+                                                                },
+                                                                Object {
+                                                                  "balance": "0.13",
+                                                                  "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                  "symbol": "BOKKY",
+                                                                  "value": Object {
+                                                                    "btc": "0.00013",
+                                                                    "eth": "0.013",
+                                                                    "usd": "0.13",
+                                                                  },
+                                                                },
+                                                              ],
+                                                              "error": null,
+                                                              "loading": false,
+                                                              "total": Object {
+                                                                "btc": "0.00213",
+                                                                "eth": "0.213",
+                                                                "usd": "82.53",
+                                                              },
+                                                            },
                                                             "nahmiiAvailable": Object {
                                                               "assets": Array [
                                                                 Object {
@@ -3372,6 +3793,16 @@ ShallowWrapper {
                                                                 "usd": "0",
                                                               },
                                                             },
+                                                            "nahmiiActive": Object {
+                                                              "assets": Array [],
+                                                              "error": true,
+                                                              "loading": false,
+                                                              "total": Object {
+                                                                "btc": "0",
+                                                                "eth": "0",
+                                                                "usd": "0",
+                                                              },
+                                                            },
                                                             "nahmiiAvailable": Object {
                                                               "assets": Array [],
                                                               "error": true,
@@ -3431,6 +3862,16 @@ ShallowWrapper {
                                                               },
                                                             },
                                                             "combined": Object {
+                                                              "assets": Array [],
+                                                              "error": null,
+                                                              "loading": true,
+                                                              "total": Object {
+                                                                "btc": "0",
+                                                                "eth": "0",
+                                                                "usd": "0",
+                                                              },
+                                                            },
+                                                            "nahmiiActive": Object {
                                                               "assets": Array [],
                                                               "error": null,
                                                               "loading": true,
@@ -3508,6 +3949,16 @@ ShallowWrapper {
                                                               "assets": Array [],
                                                               "error": null,
                                                               "loading": true,
+                                                              "total": Object {
+                                                                "btc": "0",
+                                                                "eth": "0",
+                                                                "usd": "0",
+                                                              },
+                                                            },
+                                                            "nahmiiActive": Object {
+                                                              "assets": Array [],
+                                                              "error": null,
+                                                              "loading": false,
                                                               "total": Object {
                                                                 "btc": "0",
                                                                 "eth": "0",
@@ -3734,6 +4185,37 @@ ShallowWrapper {
                                                               "usd": "164.492044000001231288",
                                                             },
                                                           },
+                                                          "nahmiiActive": Object {
+                                                            "assets": Array [
+                                                              Object {
+                                                                "balance": "0.2",
+                                                                "currency": "0x0000000000000000000000000000000000000000",
+                                                                "symbol": "ETH",
+                                                                "value": Object {
+                                                                  "btc": "0.002",
+                                                                  "eth": "0.2",
+                                                                  "usd": "82.4",
+                                                                },
+                                                              },
+                                                              Object {
+                                                                "balance": "0.13",
+                                                                "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                "symbol": "BOKKY",
+                                                                "value": Object {
+                                                                  "btc": "0.00013",
+                                                                  "eth": "0.013",
+                                                                  "usd": "0.13",
+                                                                },
+                                                              },
+                                                            ],
+                                                            "error": null,
+                                                            "loading": false,
+                                                            "total": Object {
+                                                              "btc": "0.00213",
+                                                              "eth": "0.213",
+                                                              "usd": "82.53",
+                                                            },
+                                                          },
                                                           "nahmiiAvailable": Object {
                                                             "assets": Array [
                                                               Object {
@@ -3856,6 +4338,16 @@ ShallowWrapper {
                                                               "usd": "0",
                                                             },
                                                           },
+                                                          "nahmiiActive": Object {
+                                                            "assets": Array [],
+                                                            "error": true,
+                                                            "loading": false,
+                                                            "total": Object {
+                                                              "btc": "0",
+                                                              "eth": "0",
+                                                              "usd": "0",
+                                                            },
+                                                          },
                                                           "nahmiiAvailable": Object {
                                                             "assets": Array [],
                                                             "error": true,
@@ -3915,6 +4407,16 @@ ShallowWrapper {
                                                             },
                                                           },
                                                           "combined": Object {
+                                                            "assets": Array [],
+                                                            "error": null,
+                                                            "loading": true,
+                                                            "total": Object {
+                                                              "btc": "0",
+                                                              "eth": "0",
+                                                              "usd": "0",
+                                                            },
+                                                          },
+                                                          "nahmiiActive": Object {
                                                             "assets": Array [],
                                                             "error": null,
                                                             "loading": true,
@@ -3992,6 +4494,16 @@ ShallowWrapper {
                                                             "assets": Array [],
                                                             "error": null,
                                                             "loading": true,
+                                                            "total": Object {
+                                                              "btc": "0",
+                                                              "eth": "0",
+                                                              "usd": "0",
+                                                            },
+                                                          },
+                                                          "nahmiiActive": Object {
+                                                            "assets": Array [],
+                                                            "error": null,
+                                                            "loading": false,
                                                             "total": Object {
                                                               "btc": "0",
                                                               "eth": "0",
@@ -4210,6 +4722,37 @@ ShallowWrapper {
                             "usd": "164.492044000001231288",
                           },
                         },
+                        "nahmiiActive": Object {
+                          "assets": Array [
+                            Object {
+                              "balance": "0.2",
+                              "currency": "0x0000000000000000000000000000000000000000",
+                              "symbol": "ETH",
+                              "value": Object {
+                                "btc": "0.002",
+                                "eth": "0.2",
+                                "usd": "82.4",
+                              },
+                            },
+                            Object {
+                              "balance": "0.13",
+                              "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                              "symbol": "BOKKY",
+                              "value": Object {
+                                "btc": "0.00013",
+                                "eth": "0.013",
+                                "usd": "0.13",
+                              },
+                            },
+                          ],
+                          "error": null,
+                          "loading": false,
+                          "total": Object {
+                            "btc": "0.00213",
+                            "eth": "0.213",
+                            "usd": "82.53",
+                          },
+                        },
                         "nahmiiAvailable": Object {
                           "assets": Array [
                             Object {
@@ -4332,6 +4875,16 @@ ShallowWrapper {
                             "usd": "0",
                           },
                         },
+                        "nahmiiActive": Object {
+                          "assets": Array [],
+                          "error": true,
+                          "loading": false,
+                          "total": Object {
+                            "btc": "0",
+                            "eth": "0",
+                            "usd": "0",
+                          },
+                        },
                         "nahmiiAvailable": Object {
                           "assets": Array [],
                           "error": true,
@@ -4391,6 +4944,16 @@ ShallowWrapper {
                           },
                         },
                         "combined": Object {
+                          "assets": Array [],
+                          "error": null,
+                          "loading": true,
+                          "total": Object {
+                            "btc": "0",
+                            "eth": "0",
+                            "usd": "0",
+                          },
+                        },
+                        "nahmiiActive": Object {
                           "assets": Array [],
                           "error": null,
                           "loading": true,
@@ -4468,6 +5031,16 @@ ShallowWrapper {
                           "assets": Array [],
                           "error": null,
                           "loading": true,
+                          "total": Object {
+                            "btc": "0",
+                            "eth": "0",
+                            "usd": "0",
+                          },
+                        },
+                        "nahmiiActive": Object {
+                          "assets": Array [],
+                          "error": null,
+                          "loading": false,
                           "total": Object {
                             "btc": "0",
                             "eth": "0",
@@ -4713,6 +5286,27 @@ ShallowWrapper {
                     usd: "0",
                 },
             },
+            nahmiiActive: Immutable.Map {
+                assets: Immutable.Map {
+                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                        value: Immutable.Map {
+                            usd: "82.4",
+                        },
+                        amount: "0.2",
+                    },
+                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                        value: Immutable.Map {
+                            usd: "0.13",
+                        },
+                        amount: "0.13",
+                    },
+                },
+                loading: false,
+                error: null,
+                total: Immutable.Map {
+                    usd: "82.53",
+                },
+            },
             nahmiiCombined: Immutable.Map {
                 assets: Immutable.Map {
                     0x0000000000000000000000000000000000000000: Immutable.Map {
@@ -4932,6 +5526,37 @@ ShallowWrapper {
                             usd: "82.53",
                         },
                     },
+                    nahmiiActive: Immutable.Map {
+                        loading: false,
+                        error: null,
+                        assets: Immutable.List [
+                            Immutable.Map {
+                                currency: "0x0000000000000000000000000000000000000000",
+                                balance: "0.2",
+                                symbol: "ETH",
+                                value: Immutable.Map {
+                                    eth: "0.2",
+                                    btc: "0.002",
+                                    usd: "82.4",
+                                },
+                            },
+                            Immutable.Map {
+                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                balance: "0.13",
+                                symbol: "BOKKY",
+                                value: Immutable.Map {
+                                    eth: "0.013",
+                                    btc: "0.00013",
+                                    usd: "0.13",
+                                },
+                            },
+                        ],
+                        total: Immutable.Map {
+                            eth: "0.213",
+                            btc: "0.00213",
+                            usd: "82.53",
+                        },
+                    },
                     combined: Immutable.Map {
                         loading: false,
                         error: null,
@@ -5026,6 +5651,17 @@ ShallowWrapper {
                             usd: "0",
                         },
                     },
+                    nahmiiActive: Immutable.Map {
+                        loading: false,
+                        error: true,
+                        assets: Immutable.List [
+                        ],
+                        total: Immutable.Map {
+                            eth: "0",
+                            btc: "0",
+                            usd: "0",
+                        },
+                    },
                     combined: Immutable.Map {
                         loading: false,
                         error: true,
@@ -5106,6 +5742,17 @@ ShallowWrapper {
                             usd: "0",
                         },
                     },
+                    nahmiiActive: Immutable.Map {
+                        loading: true,
+                        error: null,
+                        assets: Immutable.List [
+                        ],
+                        total: Immutable.Map {
+                            eth: "0",
+                            btc: "0",
+                            usd: "0",
+                        },
+                    },
                     combined: Immutable.Map {
                         loading: true,
                         error: null,
@@ -5171,6 +5818,17 @@ ShallowWrapper {
                         },
                     },
                     nahmiiCombined: Immutable.Map {
+                        loading: false,
+                        error: null,
+                        assets: Immutable.List [
+                        ],
+                        total: Immutable.Map {
+                            eth: "0",
+                            btc: "0",
+                            usd: "0",
+                        },
+                    },
+                    nahmiiActive: Immutable.Map {
                         loading: false,
                         error: null,
                         assets: Immutable.List [
@@ -5373,6 +6031,37 @@ ShallowWrapper {
                                                 "usd": "164.492044000001231288",
                                               },
                                             },
+                                            "nahmiiActive": Object {
+                                              "assets": Array [
+                                                Object {
+                                                  "balance": "0.2",
+                                                  "currency": "0x0000000000000000000000000000000000000000",
+                                                  "symbol": "ETH",
+                                                  "value": Object {
+                                                    "btc": "0.002",
+                                                    "eth": "0.2",
+                                                    "usd": "82.4",
+                                                  },
+                                                },
+                                                Object {
+                                                  "balance": "0.13",
+                                                  "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                  "symbol": "BOKKY",
+                                                  "value": Object {
+                                                    "btc": "0.00013",
+                                                    "eth": "0.013",
+                                                    "usd": "0.13",
+                                                  },
+                                                },
+                                              ],
+                                              "error": null,
+                                              "loading": false,
+                                              "total": Object {
+                                                "btc": "0.00213",
+                                                "eth": "0.213",
+                                                "usd": "82.53",
+                                              },
+                                            },
                                             "nahmiiAvailable": Object {
                                               "assets": Array [
                                                 Object {
@@ -5495,6 +6184,16 @@ ShallowWrapper {
                                                 "usd": "0",
                                               },
                                             },
+                                            "nahmiiActive": Object {
+                                              "assets": Array [],
+                                              "error": true,
+                                              "loading": false,
+                                              "total": Object {
+                                                "btc": "0",
+                                                "eth": "0",
+                                                "usd": "0",
+                                              },
+                                            },
                                             "nahmiiAvailable": Object {
                                               "assets": Array [],
                                               "error": true,
@@ -5554,6 +6253,16 @@ ShallowWrapper {
                                               },
                                             },
                                             "combined": Object {
+                                              "assets": Array [],
+                                              "error": null,
+                                              "loading": true,
+                                              "total": Object {
+                                                "btc": "0",
+                                                "eth": "0",
+                                                "usd": "0",
+                                              },
+                                            },
+                                            "nahmiiActive": Object {
                                               "assets": Array [],
                                               "error": null,
                                               "loading": true,
@@ -5631,6 +6340,16 @@ ShallowWrapper {
                                               "assets": Array [],
                                               "error": null,
                                               "loading": true,
+                                              "total": Object {
+                                                "btc": "0",
+                                                "eth": "0",
+                                                "usd": "0",
+                                              },
+                                            },
+                                            "nahmiiActive": Object {
+                                              "assets": Array [],
+                                              "error": null,
+                                              "loading": false,
                                               "total": Object {
                                                 "btc": "0",
                                                 "eth": "0",
@@ -5857,6 +6576,37 @@ ShallowWrapper {
                                                         "usd": "164.492044000001231288",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [
+                                                        Object {
+                                                          "balance": "0.2",
+                                                          "currency": "0x0000000000000000000000000000000000000000",
+                                                          "symbol": "ETH",
+                                                          "value": Object {
+                                                            "btc": "0.002",
+                                                            "eth": "0.2",
+                                                            "usd": "82.4",
+                                                          },
+                                                        },
+                                                        Object {
+                                                          "balance": "0.13",
+                                                          "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                          "symbol": "BOKKY",
+                                                          "value": Object {
+                                                            "btc": "0.00013",
+                                                            "eth": "0.013",
+                                                            "usd": "0.13",
+                                                          },
+                                                        },
+                                                      ],
+                                                      "error": null,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0.00213",
+                                                        "eth": "0.213",
+                                                        "usd": "82.53",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [
                                                         Object {
@@ -5979,6 +6729,16 @@ ShallowWrapper {
                                                         "usd": "0",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": true,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [],
                                                       "error": true,
@@ -6038,6 +6798,16 @@ ShallowWrapper {
                                                       },
                                                     },
                                                     "combined": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
@@ -6115,6 +6885,16 @@ ShallowWrapper {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": false,
                                                       "total": Object {
                                                         "btc": "0",
                                                         "eth": "0",
@@ -6341,6 +7121,37 @@ ShallowWrapper {
                                                         "usd": "164.492044000001231288",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [
+                                                        Object {
+                                                          "balance": "0.2",
+                                                          "currency": "0x0000000000000000000000000000000000000000",
+                                                          "symbol": "ETH",
+                                                          "value": Object {
+                                                            "btc": "0.002",
+                                                            "eth": "0.2",
+                                                            "usd": "82.4",
+                                                          },
+                                                        },
+                                                        Object {
+                                                          "balance": "0.13",
+                                                          "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                          "symbol": "BOKKY",
+                                                          "value": Object {
+                                                            "btc": "0.00013",
+                                                            "eth": "0.013",
+                                                            "usd": "0.13",
+                                                          },
+                                                        },
+                                                      ],
+                                                      "error": null,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0.00213",
+                                                        "eth": "0.213",
+                                                        "usd": "82.53",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [
                                                         Object {
@@ -6463,6 +7274,16 @@ ShallowWrapper {
                                                         "usd": "0",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": true,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [],
                                                       "error": true,
@@ -6522,6 +7343,16 @@ ShallowWrapper {
                                                       },
                                                     },
                                                     "combined": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
@@ -6599,6 +7430,16 @@ ShallowWrapper {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": false,
                                                       "total": Object {
                                                         "btc": "0",
                                                         "eth": "0",
@@ -6817,6 +7658,37 @@ ShallowWrapper {
                           "usd": "164.492044000001231288",
                         },
                       },
+                      "nahmiiActive": Object {
+                        "assets": Array [
+                          Object {
+                            "balance": "0.2",
+                            "currency": "0x0000000000000000000000000000000000000000",
+                            "symbol": "ETH",
+                            "value": Object {
+                              "btc": "0.002",
+                              "eth": "0.2",
+                              "usd": "82.4",
+                            },
+                          },
+                          Object {
+                            "balance": "0.13",
+                            "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            "symbol": "BOKKY",
+                            "value": Object {
+                              "btc": "0.00013",
+                              "eth": "0.013",
+                              "usd": "0.13",
+                            },
+                          },
+                        ],
+                        "error": null,
+                        "loading": false,
+                        "total": Object {
+                          "btc": "0.00213",
+                          "eth": "0.213",
+                          "usd": "82.53",
+                        },
+                      },
                       "nahmiiAvailable": Object {
                         "assets": Array [
                           Object {
@@ -6939,6 +7811,16 @@ ShallowWrapper {
                           "usd": "0",
                         },
                       },
+                      "nahmiiActive": Object {
+                        "assets": Array [],
+                        "error": true,
+                        "loading": false,
+                        "total": Object {
+                          "btc": "0",
+                          "eth": "0",
+                          "usd": "0",
+                        },
+                      },
                       "nahmiiAvailable": Object {
                         "assets": Array [],
                         "error": true,
@@ -6998,6 +7880,16 @@ ShallowWrapper {
                         },
                       },
                       "combined": Object {
+                        "assets": Array [],
+                        "error": null,
+                        "loading": true,
+                        "total": Object {
+                          "btc": "0",
+                          "eth": "0",
+                          "usd": "0",
+                        },
+                      },
+                      "nahmiiActive": Object {
                         "assets": Array [],
                         "error": null,
                         "loading": true,
@@ -7075,6 +7967,16 @@ ShallowWrapper {
                         "assets": Array [],
                         "error": null,
                         "loading": true,
+                        "total": Object {
+                          "btc": "0",
+                          "eth": "0",
+                          "usd": "0",
+                        },
+                      },
+                      "nahmiiActive": Object {
+                        "assets": Array [],
+                        "error": null,
+                        "loading": false,
                         "total": Object {
                           "btc": "0",
                           "eth": "0",
@@ -7325,6 +8227,37 @@ ShallowWrapper {
                                                           "usd": "164.492044000001231288",
                                                         },
                                                       },
+                                                      "nahmiiActive": Object {
+                                                        "assets": Array [
+                                                          Object {
+                                                            "balance": "0.2",
+                                                            "currency": "0x0000000000000000000000000000000000000000",
+                                                            "symbol": "ETH",
+                                                            "value": Object {
+                                                              "btc": "0.002",
+                                                              "eth": "0.2",
+                                                              "usd": "82.4",
+                                                            },
+                                                          },
+                                                          Object {
+                                                            "balance": "0.13",
+                                                            "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                            "symbol": "BOKKY",
+                                                            "value": Object {
+                                                              "btc": "0.00013",
+                                                              "eth": "0.013",
+                                                              "usd": "0.13",
+                                                            },
+                                                          },
+                                                        ],
+                                                        "error": null,
+                                                        "loading": false,
+                                                        "total": Object {
+                                                          "btc": "0.00213",
+                                                          "eth": "0.213",
+                                                          "usd": "82.53",
+                                                        },
+                                                      },
                                                       "nahmiiAvailable": Object {
                                                         "assets": Array [
                                                           Object {
@@ -7447,6 +8380,16 @@ ShallowWrapper {
                                                           "usd": "0",
                                                         },
                                                       },
+                                                      "nahmiiActive": Object {
+                                                        "assets": Array [],
+                                                        "error": true,
+                                                        "loading": false,
+                                                        "total": Object {
+                                                          "btc": "0",
+                                                          "eth": "0",
+                                                          "usd": "0",
+                                                        },
+                                                      },
                                                       "nahmiiAvailable": Object {
                                                         "assets": Array [],
                                                         "error": true,
@@ -7506,6 +8449,16 @@ ShallowWrapper {
                                                         },
                                                       },
                                                       "combined": Object {
+                                                        "assets": Array [],
+                                                        "error": null,
+                                                        "loading": true,
+                                                        "total": Object {
+                                                          "btc": "0",
+                                                          "eth": "0",
+                                                          "usd": "0",
+                                                        },
+                                                      },
+                                                      "nahmiiActive": Object {
                                                         "assets": Array [],
                                                         "error": null,
                                                         "loading": true,
@@ -7583,6 +8536,16 @@ ShallowWrapper {
                                                         "assets": Array [],
                                                         "error": null,
                                                         "loading": true,
+                                                        "total": Object {
+                                                          "btc": "0",
+                                                          "eth": "0",
+                                                          "usd": "0",
+                                                        },
+                                                      },
+                                                      "nahmiiActive": Object {
+                                                        "assets": Array [],
+                                                        "error": null,
+                                                        "loading": false,
                                                         "total": Object {
                                                           "btc": "0",
                                                           "eth": "0",
@@ -7809,6 +8772,37 @@ ShallowWrapper {
                                                                 "usd": "164.492044000001231288",
                                                               },
                                                             },
+                                                            "nahmiiActive": Object {
+                                                              "assets": Array [
+                                                                Object {
+                                                                  "balance": "0.2",
+                                                                  "currency": "0x0000000000000000000000000000000000000000",
+                                                                  "symbol": "ETH",
+                                                                  "value": Object {
+                                                                    "btc": "0.002",
+                                                                    "eth": "0.2",
+                                                                    "usd": "82.4",
+                                                                  },
+                                                                },
+                                                                Object {
+                                                                  "balance": "0.13",
+                                                                  "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                  "symbol": "BOKKY",
+                                                                  "value": Object {
+                                                                    "btc": "0.00013",
+                                                                    "eth": "0.013",
+                                                                    "usd": "0.13",
+                                                                  },
+                                                                },
+                                                              ],
+                                                              "error": null,
+                                                              "loading": false,
+                                                              "total": Object {
+                                                                "btc": "0.00213",
+                                                                "eth": "0.213",
+                                                                "usd": "82.53",
+                                                              },
+                                                            },
                                                             "nahmiiAvailable": Object {
                                                               "assets": Array [
                                                                 Object {
@@ -7931,6 +8925,16 @@ ShallowWrapper {
                                                                 "usd": "0",
                                                               },
                                                             },
+                                                            "nahmiiActive": Object {
+                                                              "assets": Array [],
+                                                              "error": true,
+                                                              "loading": false,
+                                                              "total": Object {
+                                                                "btc": "0",
+                                                                "eth": "0",
+                                                                "usd": "0",
+                                                              },
+                                                            },
                                                             "nahmiiAvailable": Object {
                                                               "assets": Array [],
                                                               "error": true,
@@ -7990,6 +8994,16 @@ ShallowWrapper {
                                                               },
                                                             },
                                                             "combined": Object {
+                                                              "assets": Array [],
+                                                              "error": null,
+                                                              "loading": true,
+                                                              "total": Object {
+                                                                "btc": "0",
+                                                                "eth": "0",
+                                                                "usd": "0",
+                                                              },
+                                                            },
+                                                            "nahmiiActive": Object {
                                                               "assets": Array [],
                                                               "error": null,
                                                               "loading": true,
@@ -8067,6 +9081,16 @@ ShallowWrapper {
                                                               "assets": Array [],
                                                               "error": null,
                                                               "loading": true,
+                                                              "total": Object {
+                                                                "btc": "0",
+                                                                "eth": "0",
+                                                                "usd": "0",
+                                                              },
+                                                            },
+                                                            "nahmiiActive": Object {
+                                                              "assets": Array [],
+                                                              "error": null,
+                                                              "loading": false,
                                                               "total": Object {
                                                                 "btc": "0",
                                                                 "eth": "0",
@@ -8293,6 +9317,37 @@ ShallowWrapper {
                                                               "usd": "164.492044000001231288",
                                                             },
                                                           },
+                                                          "nahmiiActive": Object {
+                                                            "assets": Array [
+                                                              Object {
+                                                                "balance": "0.2",
+                                                                "currency": "0x0000000000000000000000000000000000000000",
+                                                                "symbol": "ETH",
+                                                                "value": Object {
+                                                                  "btc": "0.002",
+                                                                  "eth": "0.2",
+                                                                  "usd": "82.4",
+                                                                },
+                                                              },
+                                                              Object {
+                                                                "balance": "0.13",
+                                                                "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                "symbol": "BOKKY",
+                                                                "value": Object {
+                                                                  "btc": "0.00013",
+                                                                  "eth": "0.013",
+                                                                  "usd": "0.13",
+                                                                },
+                                                              },
+                                                            ],
+                                                            "error": null,
+                                                            "loading": false,
+                                                            "total": Object {
+                                                              "btc": "0.00213",
+                                                              "eth": "0.213",
+                                                              "usd": "82.53",
+                                                            },
+                                                          },
                                                           "nahmiiAvailable": Object {
                                                             "assets": Array [
                                                               Object {
@@ -8415,6 +9470,16 @@ ShallowWrapper {
                                                               "usd": "0",
                                                             },
                                                           },
+                                                          "nahmiiActive": Object {
+                                                            "assets": Array [],
+                                                            "error": true,
+                                                            "loading": false,
+                                                            "total": Object {
+                                                              "btc": "0",
+                                                              "eth": "0",
+                                                              "usd": "0",
+                                                            },
+                                                          },
                                                           "nahmiiAvailable": Object {
                                                             "assets": Array [],
                                                             "error": true,
@@ -8474,6 +9539,16 @@ ShallowWrapper {
                                                             },
                                                           },
                                                           "combined": Object {
+                                                            "assets": Array [],
+                                                            "error": null,
+                                                            "loading": true,
+                                                            "total": Object {
+                                                              "btc": "0",
+                                                              "eth": "0",
+                                                              "usd": "0",
+                                                            },
+                                                          },
+                                                          "nahmiiActive": Object {
                                                             "assets": Array [],
                                                             "error": null,
                                                             "loading": true,
@@ -8551,6 +9626,16 @@ ShallowWrapper {
                                                             "assets": Array [],
                                                             "error": null,
                                                             "loading": true,
+                                                            "total": Object {
+                                                              "btc": "0",
+                                                              "eth": "0",
+                                                              "usd": "0",
+                                                            },
+                                                          },
+                                                          "nahmiiActive": Object {
+                                                            "assets": Array [],
+                                                            "error": null,
+                                                            "loading": false,
                                                             "total": Object {
                                                               "btc": "0",
                                                               "eth": "0",
@@ -8769,6 +9854,37 @@ ShallowWrapper {
                             "usd": "164.492044000001231288",
                           },
                         },
+                        "nahmiiActive": Object {
+                          "assets": Array [
+                            Object {
+                              "balance": "0.2",
+                              "currency": "0x0000000000000000000000000000000000000000",
+                              "symbol": "ETH",
+                              "value": Object {
+                                "btc": "0.002",
+                                "eth": "0.2",
+                                "usd": "82.4",
+                              },
+                            },
+                            Object {
+                              "balance": "0.13",
+                              "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                              "symbol": "BOKKY",
+                              "value": Object {
+                                "btc": "0.00013",
+                                "eth": "0.013",
+                                "usd": "0.13",
+                              },
+                            },
+                          ],
+                          "error": null,
+                          "loading": false,
+                          "total": Object {
+                            "btc": "0.00213",
+                            "eth": "0.213",
+                            "usd": "82.53",
+                          },
+                        },
                         "nahmiiAvailable": Object {
                           "assets": Array [
                             Object {
@@ -8891,6 +10007,16 @@ ShallowWrapper {
                             "usd": "0",
                           },
                         },
+                        "nahmiiActive": Object {
+                          "assets": Array [],
+                          "error": true,
+                          "loading": false,
+                          "total": Object {
+                            "btc": "0",
+                            "eth": "0",
+                            "usd": "0",
+                          },
+                        },
                         "nahmiiAvailable": Object {
                           "assets": Array [],
                           "error": true,
@@ -8950,6 +10076,16 @@ ShallowWrapper {
                           },
                         },
                         "combined": Object {
+                          "assets": Array [],
+                          "error": null,
+                          "loading": true,
+                          "total": Object {
+                            "btc": "0",
+                            "eth": "0",
+                            "usd": "0",
+                          },
+                        },
+                        "nahmiiActive": Object {
                           "assets": Array [],
                           "error": null,
                           "loading": true,
@@ -9027,6 +10163,16 @@ ShallowWrapper {
                           "assets": Array [],
                           "error": null,
                           "loading": true,
+                          "total": Object {
+                            "btc": "0",
+                            "eth": "0",
+                            "usd": "0",
+                          },
+                        },
+                        "nahmiiActive": Object {
+                          "assets": Array [],
+                          "error": null,
+                          "loading": false,
                           "total": Object {
                             "btc": "0",
                             "eth": "0",
@@ -9308,6 +10454,27 @@ ShallowWrapper {
                     usd: "0",
                 },
             },
+            nahmiiActive: Immutable.Map {
+                assets: Immutable.Map {
+                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                        value: Immutable.Map {
+                            usd: "82.4",
+                        },
+                        amount: "0.2",
+                    },
+                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                        value: Immutable.Map {
+                            usd: "0.13",
+                        },
+                        amount: "0.13",
+                    },
+                },
+                loading: false,
+                error: null,
+                total: Immutable.Map {
+                    usd: "82.53",
+                },
+            },
             nahmiiCombined: Immutable.Map {
                 assets: Immutable.Map {
                     0x0000000000000000000000000000000000000000: Immutable.Map {
@@ -9552,6 +10719,27 @@ ShallowWrapper {
                                                                 usd: "0",
                                                         },
                                                 },
+                                                nahmiiActive: Immutable.Map {
+                                                        assets: Immutable.Map {
+                                                                0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                        value: Immutable.Map {
+                                                                                usd: "82.4",
+                                                                        },
+                                                                        amount: "0.2",
+                                                                },
+                                                                0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                        value: Immutable.Map {
+                                                                                usd: "0.13",
+                                                                        },
+                                                                        amount: "0.13",
+                                                                },
+                                                        },
+                                                        loading: false,
+                                                        error: null,
+                                                        total: Immutable.Map {
+                                                                usd: "82.53",
+                                                        },
+                                                },
                                                 nahmiiCombined: Immutable.Map {
                                                         assets: Immutable.Map {
                                                                 0x0000000000000000000000000000000000000000: Immutable.Map {
@@ -9740,6 +10928,27 @@ ShallowWrapper {
                                                                         error: null,
                                                                         total: Immutable.Map {
                                                                                     usd: "0",
+                                                                        },
+                                                            },
+                                                            nahmiiActive: Immutable.Map {
+                                                                        assets: Immutable.Map {
+                                                                                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                value: Immutable.Map {
+                                                                                                            usd: "82.4",
+                                                                                                },
+                                                                                                amount: "0.2",
+                                                                                    },
+                                                                                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                value: Immutable.Map {
+                                                                                                            usd: "0.13",
+                                                                                                },
+                                                                                                amount: "0.13",
+                                                                                    },
+                                                                        },
+                                                                        loading: false,
+                                                                        error: null,
+                                                                        total: Immutable.Map {
+                                                                                    usd: "82.53",
                                                                         },
                                                             },
                                                             nahmiiCombined: Immutable.Map {
@@ -9963,6 +11172,27 @@ ShallowWrapper {
                                                                                     usd: "0",
                                                                       },
                                                         },
+                                                        nahmiiActive: Immutable.Map {
+                                                                      assets: Immutable.Map {
+                                                                                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                  value: Immutable.Map {
+                                                                                                                usd: "82.4",
+                                                                                                  },
+                                                                                                  amount: "0.2",
+                                                                                    },
+                                                                                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                  value: Immutable.Map {
+                                                                                                                usd: "0.13",
+                                                                                                  },
+                                                                                                  amount: "0.13",
+                                                                                    },
+                                                                      },
+                                                                      loading: false,
+                                                                      error: null,
+                                                                      total: Immutable.Map {
+                                                                                    usd: "82.53",
+                                                                      },
+                                                        },
                                                         nahmiiCombined: Immutable.Map {
                                                                       assets: Immutable.Map {
                                                                                     0x0000000000000000000000000000000000000000: Immutable.Map {
@@ -10134,6 +11364,27 @@ ShallowWrapper {
                                                                         error: null,
                                                                         total: Immutable.Map {
                                                                                           usd: "0",
+                                                                        },
+                                                      },
+                                                      nahmiiActive: Immutable.Map {
+                                                                        assets: Immutable.Map {
+                                                                                          0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                            value: Immutable.Map {
+                                                                                                                              usd: "82.4",
+                                                                                                            },
+                                                                                                            amount: "0.2",
+                                                                                          },
+                                                                                          0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                            value: Immutable.Map {
+                                                                                                                              usd: "0.13",
+                                                                                                            },
+                                                                                                            amount: "0.13",
+                                                                                          },
+                                                                        },
+                                                                        loading: false,
+                                                                        error: null,
+                                                                        total: Immutable.Map {
+                                                                                          usd: "82.53",
                                                                         },
                                                       },
                                                       nahmiiCombined: Immutable.Map {
@@ -10308,6 +11559,27 @@ ShallowWrapper {
                                         error: null,
                                         total: Immutable.Map {
                                                             usd: "0",
+                                        },
+                    },
+                    nahmiiActive: Immutable.Map {
+                                        assets: Immutable.Map {
+                                                            0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                value: Immutable.Map {
+                                                                                                    usd: "82.4",
+                                                                                },
+                                                                                amount: "0.2",
+                                                            },
+                                                            0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                value: Immutable.Map {
+                                                                                                    usd: "0.13",
+                                                                                },
+                                                                                amount: "0.13",
+                                                            },
+                                        },
+                                        loading: false,
+                                        error: null,
+                                        total: Immutable.Map {
+                                                            usd: "82.53",
                                         },
                     },
                     nahmiiCombined: Immutable.Map {
@@ -10516,6 +11788,27 @@ ShallowWrapper {
                                                                                 usd: "0",
                                                                       },
                                                             },
+                                                            nahmiiActive: Immutable.Map {
+                                                                      assets: Immutable.Map {
+                                                                                0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                          value: Immutable.Map {
+                                                                                                    usd: "82.4",
+                                                                                          },
+                                                                                          amount: "0.2",
+                                                                                },
+                                                                                0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                          value: Immutable.Map {
+                                                                                                    usd: "0.13",
+                                                                                          },
+                                                                                          amount: "0.13",
+                                                                                },
+                                                                      },
+                                                                      loading: false,
+                                                                      error: null,
+                                                                      total: Immutable.Map {
+                                                                                usd: "82.53",
+                                                                      },
+                                                            },
                                                             nahmiiCombined: Immutable.Map {
                                                                       assets: Immutable.Map {
                                                                                 0x0000000000000000000000000000000000000000: Immutable.Map {
@@ -10704,6 +11997,27 @@ ShallowWrapper {
                                                                                     error: null,
                                                                                     total: Immutable.Map {
                                                                                                   usd: "0",
+                                                                                    },
+                                                                      },
+                                                                      nahmiiActive: Immutable.Map {
+                                                                                    assets: Immutable.Map {
+                                                                                                  0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                                value: Immutable.Map {
+                                                                                                                              usd: "82.4",
+                                                                                                                },
+                                                                                                                amount: "0.2",
+                                                                                                  },
+                                                                                                  0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                                value: Immutable.Map {
+                                                                                                                              usd: "0.13",
+                                                                                                                },
+                                                                                                                amount: "0.13",
+                                                                                                  },
+                                                                                    },
+                                                                                    loading: false,
+                                                                                    error: null,
+                                                                                    total: Immutable.Map {
+                                                                                                  usd: "82.53",
                                                                                     },
                                                                       },
                                                                       nahmiiCombined: Immutable.Map {
@@ -10927,6 +12241,27 @@ ShallowWrapper {
                                                                                                 usd: "0",
                                                                                 },
                                                                 },
+                                                                nahmiiActive: Immutable.Map {
+                                                                                assets: Immutable.Map {
+                                                                                                0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                                value: Immutable.Map {
+                                                                                                                                usd: "82.4",
+                                                                                                                },
+                                                                                                                amount: "0.2",
+                                                                                                },
+                                                                                                0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                                value: Immutable.Map {
+                                                                                                                                usd: "0.13",
+                                                                                                                },
+                                                                                                                amount: "0.13",
+                                                                                                },
+                                                                                },
+                                                                                loading: false,
+                                                                                error: null,
+                                                                                total: Immutable.Map {
+                                                                                                usd: "82.53",
+                                                                                },
+                                                                },
                                                                 nahmiiCombined: Immutable.Map {
                                                                                 assets: Immutable.Map {
                                                                                                 0x0000000000000000000000000000000000000000: Immutable.Map {
@@ -11098,6 +12433,27 @@ ShallowWrapper {
                                                                                 error: null,
                                                                                 total: Immutable.Map {
                                                                                                     usd: "0",
+                                                                                },
+                                                            },
+                                                            nahmiiActive: Immutable.Map {
+                                                                                assets: Immutable.Map {
+                                                                                                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                                        value: Immutable.Map {
+                                                                                                                                            usd: "82.4",
+                                                                                                                        },
+                                                                                                                        amount: "0.2",
+                                                                                                    },
+                                                                                                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                                        value: Immutable.Map {
+                                                                                                                                            usd: "0.13",
+                                                                                                                        },
+                                                                                                                        amount: "0.13",
+                                                                                                    },
+                                                                                },
+                                                                                loading: false,
+                                                                                error: null,
+                                                                                total: Immutable.Map {
+                                                                                                    usd: "82.53",
                                                                                 },
                                                             },
                                                             nahmiiCombined: Immutable.Map {
@@ -11272,6 +12628,27 @@ ShallowWrapper {
                                             error: null,
                                             total: Immutable.Map {
                                                                   usd: "0",
+                                            },
+                      },
+                      nahmiiActive: Immutable.Map {
+                                            assets: Immutable.Map {
+                                                                  0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                        value: Immutable.Map {
+                                                                                                              usd: "82.4",
+                                                                                        },
+                                                                                        amount: "0.2",
+                                                                  },
+                                                                  0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                        value: Immutable.Map {
+                                                                                                              usd: "0.13",
+                                                                                        },
+                                                                                        amount: "0.13",
+                                                                  },
+                                            },
+                                            loading: false,
+                                            error: null,
+                                            total: Immutable.Map {
+                                                                  usd: "82.53",
                                             },
                       },
                       nahmiiCombined: Immutable.Map {
@@ -11533,6 +12910,27 @@ ShallowWrapper {
                     usd: "0",
                 },
             },
+            nahmiiActive: Immutable.Map {
+                assets: Immutable.Map {
+                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                        value: Immutable.Map {
+                            usd: "82.4",
+                        },
+                        amount: "0.2",
+                    },
+                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                        value: Immutable.Map {
+                            usd: "0.13",
+                        },
+                        amount: "0.13",
+                    },
+                },
+                loading: false,
+                error: null,
+                total: Immutable.Map {
+                    usd: "82.53",
+                },
+            },
             nahmiiCombined: Immutable.Map {
                 assets: Immutable.Map {
                     0x0000000000000000000000000000000000000000: Immutable.Map {
@@ -11777,6 +13175,27 @@ ShallowWrapper {
                                                                 usd: "0",
                                                         },
                                                 },
+                                                nahmiiActive: Immutable.Map {
+                                                        assets: Immutable.Map {
+                                                                0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                        value: Immutable.Map {
+                                                                                usd: "82.4",
+                                                                        },
+                                                                        amount: "0.2",
+                                                                },
+                                                                0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                        value: Immutable.Map {
+                                                                                usd: "0.13",
+                                                                        },
+                                                                        amount: "0.13",
+                                                                },
+                                                        },
+                                                        loading: false,
+                                                        error: null,
+                                                        total: Immutable.Map {
+                                                                usd: "82.53",
+                                                        },
+                                                },
                                                 nahmiiCombined: Immutable.Map {
                                                         assets: Immutable.Map {
                                                                 0x0000000000000000000000000000000000000000: Immutable.Map {
@@ -11965,6 +13384,27 @@ ShallowWrapper {
                                                                         error: null,
                                                                         total: Immutable.Map {
                                                                                     usd: "0",
+                                                                        },
+                                                            },
+                                                            nahmiiActive: Immutable.Map {
+                                                                        assets: Immutable.Map {
+                                                                                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                value: Immutable.Map {
+                                                                                                            usd: "82.4",
+                                                                                                },
+                                                                                                amount: "0.2",
+                                                                                    },
+                                                                                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                value: Immutable.Map {
+                                                                                                            usd: "0.13",
+                                                                                                },
+                                                                                                amount: "0.13",
+                                                                                    },
+                                                                        },
+                                                                        loading: false,
+                                                                        error: null,
+                                                                        total: Immutable.Map {
+                                                                                    usd: "82.53",
                                                                         },
                                                             },
                                                             nahmiiCombined: Immutable.Map {
@@ -12188,6 +13628,27 @@ ShallowWrapper {
                                                                                     usd: "0",
                                                                       },
                                                         },
+                                                        nahmiiActive: Immutable.Map {
+                                                                      assets: Immutable.Map {
+                                                                                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                  value: Immutable.Map {
+                                                                                                                usd: "82.4",
+                                                                                                  },
+                                                                                                  amount: "0.2",
+                                                                                    },
+                                                                                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                  value: Immutable.Map {
+                                                                                                                usd: "0.13",
+                                                                                                  },
+                                                                                                  amount: "0.13",
+                                                                                    },
+                                                                      },
+                                                                      loading: false,
+                                                                      error: null,
+                                                                      total: Immutable.Map {
+                                                                                    usd: "82.53",
+                                                                      },
+                                                        },
                                                         nahmiiCombined: Immutable.Map {
                                                                       assets: Immutable.Map {
                                                                                     0x0000000000000000000000000000000000000000: Immutable.Map {
@@ -12359,6 +13820,27 @@ ShallowWrapper {
                                                                         error: null,
                                                                         total: Immutable.Map {
                                                                                           usd: "0",
+                                                                        },
+                                                      },
+                                                      nahmiiActive: Immutable.Map {
+                                                                        assets: Immutable.Map {
+                                                                                          0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                            value: Immutable.Map {
+                                                                                                                              usd: "82.4",
+                                                                                                            },
+                                                                                                            amount: "0.2",
+                                                                                          },
+                                                                                          0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                            value: Immutable.Map {
+                                                                                                                              usd: "0.13",
+                                                                                                            },
+                                                                                                            amount: "0.13",
+                                                                                          },
+                                                                        },
+                                                                        loading: false,
+                                                                        error: null,
+                                                                        total: Immutable.Map {
+                                                                                          usd: "82.53",
                                                                         },
                                                       },
                                                       nahmiiCombined: Immutable.Map {
@@ -12533,6 +14015,27 @@ ShallowWrapper {
                                         error: null,
                                         total: Immutable.Map {
                                                             usd: "0",
+                                        },
+                    },
+                    nahmiiActive: Immutable.Map {
+                                        assets: Immutable.Map {
+                                                            0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                value: Immutable.Map {
+                                                                                                    usd: "82.4",
+                                                                                },
+                                                                                amount: "0.2",
+                                                            },
+                                                            0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                value: Immutable.Map {
+                                                                                                    usd: "0.13",
+                                                                                },
+                                                                                amount: "0.13",
+                                                            },
+                                        },
+                                        loading: false,
+                                        error: null,
+                                        total: Immutable.Map {
+                                                            usd: "82.53",
                                         },
                     },
                     nahmiiCombined: Immutable.Map {
@@ -12741,6 +14244,27 @@ ShallowWrapper {
                                                                                 usd: "0",
                                                                       },
                                                             },
+                                                            nahmiiActive: Immutable.Map {
+                                                                      assets: Immutable.Map {
+                                                                                0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                          value: Immutable.Map {
+                                                                                                    usd: "82.4",
+                                                                                          },
+                                                                                          amount: "0.2",
+                                                                                },
+                                                                                0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                          value: Immutable.Map {
+                                                                                                    usd: "0.13",
+                                                                                          },
+                                                                                          amount: "0.13",
+                                                                                },
+                                                                      },
+                                                                      loading: false,
+                                                                      error: null,
+                                                                      total: Immutable.Map {
+                                                                                usd: "82.53",
+                                                                      },
+                                                            },
                                                             nahmiiCombined: Immutable.Map {
                                                                       assets: Immutable.Map {
                                                                                 0x0000000000000000000000000000000000000000: Immutable.Map {
@@ -12929,6 +14453,27 @@ ShallowWrapper {
                                                                                     error: null,
                                                                                     total: Immutable.Map {
                                                                                                   usd: "0",
+                                                                                    },
+                                                                      },
+                                                                      nahmiiActive: Immutable.Map {
+                                                                                    assets: Immutable.Map {
+                                                                                                  0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                                value: Immutable.Map {
+                                                                                                                              usd: "82.4",
+                                                                                                                },
+                                                                                                                amount: "0.2",
+                                                                                                  },
+                                                                                                  0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                                value: Immutable.Map {
+                                                                                                                              usd: "0.13",
+                                                                                                                },
+                                                                                                                amount: "0.13",
+                                                                                                  },
+                                                                                    },
+                                                                                    loading: false,
+                                                                                    error: null,
+                                                                                    total: Immutable.Map {
+                                                                                                  usd: "82.53",
                                                                                     },
                                                                       },
                                                                       nahmiiCombined: Immutable.Map {
@@ -13152,6 +14697,27 @@ ShallowWrapper {
                                                                                                 usd: "0",
                                                                                 },
                                                                 },
+                                                                nahmiiActive: Immutable.Map {
+                                                                                assets: Immutable.Map {
+                                                                                                0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                                value: Immutable.Map {
+                                                                                                                                usd: "82.4",
+                                                                                                                },
+                                                                                                                amount: "0.2",
+                                                                                                },
+                                                                                                0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                                value: Immutable.Map {
+                                                                                                                                usd: "0.13",
+                                                                                                                },
+                                                                                                                amount: "0.13",
+                                                                                                },
+                                                                                },
+                                                                                loading: false,
+                                                                                error: null,
+                                                                                total: Immutable.Map {
+                                                                                                usd: "82.53",
+                                                                                },
+                                                                },
                                                                 nahmiiCombined: Immutable.Map {
                                                                                 assets: Immutable.Map {
                                                                                                 0x0000000000000000000000000000000000000000: Immutable.Map {
@@ -13323,6 +14889,27 @@ ShallowWrapper {
                                                                                 error: null,
                                                                                 total: Immutable.Map {
                                                                                                     usd: "0",
+                                                                                },
+                                                            },
+                                                            nahmiiActive: Immutable.Map {
+                                                                                assets: Immutable.Map {
+                                                                                                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                                        value: Immutable.Map {
+                                                                                                                                            usd: "82.4",
+                                                                                                                        },
+                                                                                                                        amount: "0.2",
+                                                                                                    },
+                                                                                                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                                        value: Immutable.Map {
+                                                                                                                                            usd: "0.13",
+                                                                                                                        },
+                                                                                                                        amount: "0.13",
+                                                                                                    },
+                                                                                },
+                                                                                loading: false,
+                                                                                error: null,
+                                                                                total: Immutable.Map {
+                                                                                                    usd: "82.53",
                                                                                 },
                                                             },
                                                             nahmiiCombined: Immutable.Map {
@@ -13497,6 +15084,27 @@ ShallowWrapper {
                                             error: null,
                                             total: Immutable.Map {
                                                                   usd: "0",
+                                            },
+                      },
+                      nahmiiActive: Immutable.Map {
+                                            assets: Immutable.Map {
+                                                                  0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                        value: Immutable.Map {
+                                                                                                              usd: "82.4",
+                                                                                        },
+                                                                                        amount: "0.2",
+                                                                  },
+                                                                  0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                        value: Immutable.Map {
+                                                                                                              usd: "0.13",
+                                                                                        },
+                                                                                        amount: "0.13",
+                                                                  },
+                                            },
+                                            loading: false,
+                                            error: null,
+                                            total: Immutable.Map {
+                                                                  usd: "82.53",
                                             },
                       },
                       nahmiiCombined: Immutable.Map {
@@ -13758,6 +15366,27 @@ ShallowWrapper {
                     usd: "0",
                 },
             },
+            nahmiiActive: Immutable.Map {
+                assets: Immutable.Map {
+                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                        value: Immutable.Map {
+                            usd: "82.4",
+                        },
+                        amount: "0.2",
+                    },
+                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                        value: Immutable.Map {
+                            usd: "0.13",
+                        },
+                        amount: "0.13",
+                    },
+                },
+                loading: false,
+                error: null,
+                total: Immutable.Map {
+                    usd: "82.53",
+                },
+            },
             nahmiiCombined: Immutable.Map {
                 assets: Immutable.Map {
                     0x0000000000000000000000000000000000000000: Immutable.Map {
@@ -13977,6 +15606,37 @@ ShallowWrapper {
                             usd: "82.53",
                         },
                     },
+                    nahmiiActive: Immutable.Map {
+                        loading: false,
+                        error: null,
+                        assets: Immutable.List [
+                            Immutable.Map {
+                                currency: "0x0000000000000000000000000000000000000000",
+                                balance: "0.2",
+                                symbol: "ETH",
+                                value: Immutable.Map {
+                                    eth: "0.2",
+                                    btc: "0.002",
+                                    usd: "82.4",
+                                },
+                            },
+                            Immutable.Map {
+                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                balance: "0.13",
+                                symbol: "BOKKY",
+                                value: Immutable.Map {
+                                    eth: "0.013",
+                                    btc: "0.00013",
+                                    usd: "0.13",
+                                },
+                            },
+                        ],
+                        total: Immutable.Map {
+                            eth: "0.213",
+                            btc: "0.00213",
+                            usd: "82.53",
+                        },
+                    },
                     combined: Immutable.Map {
                         loading: false,
                         error: null,
@@ -14071,6 +15731,17 @@ ShallowWrapper {
                             usd: "0",
                         },
                     },
+                    nahmiiActive: Immutable.Map {
+                        loading: false,
+                        error: true,
+                        assets: Immutable.List [
+                        ],
+                        total: Immutable.Map {
+                            eth: "0",
+                            btc: "0",
+                            usd: "0",
+                        },
+                    },
                     combined: Immutable.Map {
                         loading: false,
                         error: true,
@@ -14151,6 +15822,17 @@ ShallowWrapper {
                             usd: "0",
                         },
                     },
+                    nahmiiActive: Immutable.Map {
+                        loading: true,
+                        error: null,
+                        assets: Immutable.List [
+                        ],
+                        total: Immutable.Map {
+                            eth: "0",
+                            btc: "0",
+                            usd: "0",
+                        },
+                    },
                     combined: Immutable.Map {
                         loading: true,
                         error: null,
@@ -14216,6 +15898,17 @@ ShallowWrapper {
                         },
                     },
                     nahmiiCombined: Immutable.Map {
+                        loading: false,
+                        error: null,
+                        assets: Immutable.List [
+                        ],
+                        total: Immutable.Map {
+                            eth: "0",
+                            btc: "0",
+                            usd: "0",
+                        },
+                    },
+                    nahmiiActive: Immutable.Map {
                         loading: false,
                         error: null,
                         assets: Immutable.List [
@@ -14418,6 +16111,37 @@ ShallowWrapper {
                                                 "usd": "164.492044000001231288",
                                               },
                                             },
+                                            "nahmiiActive": Object {
+                                              "assets": Array [
+                                                Object {
+                                                  "balance": "0.2",
+                                                  "currency": "0x0000000000000000000000000000000000000000",
+                                                  "symbol": "ETH",
+                                                  "value": Object {
+                                                    "btc": "0.002",
+                                                    "eth": "0.2",
+                                                    "usd": "82.4",
+                                                  },
+                                                },
+                                                Object {
+                                                  "balance": "0.13",
+                                                  "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                  "symbol": "BOKKY",
+                                                  "value": Object {
+                                                    "btc": "0.00013",
+                                                    "eth": "0.013",
+                                                    "usd": "0.13",
+                                                  },
+                                                },
+                                              ],
+                                              "error": null,
+                                              "loading": false,
+                                              "total": Object {
+                                                "btc": "0.00213",
+                                                "eth": "0.213",
+                                                "usd": "82.53",
+                                              },
+                                            },
                                             "nahmiiAvailable": Object {
                                               "assets": Array [
                                                 Object {
@@ -14540,6 +16264,16 @@ ShallowWrapper {
                                                 "usd": "0",
                                               },
                                             },
+                                            "nahmiiActive": Object {
+                                              "assets": Array [],
+                                              "error": true,
+                                              "loading": false,
+                                              "total": Object {
+                                                "btc": "0",
+                                                "eth": "0",
+                                                "usd": "0",
+                                              },
+                                            },
                                             "nahmiiAvailable": Object {
                                               "assets": Array [],
                                               "error": true,
@@ -14599,6 +16333,16 @@ ShallowWrapper {
                                               },
                                             },
                                             "combined": Object {
+                                              "assets": Array [],
+                                              "error": null,
+                                              "loading": true,
+                                              "total": Object {
+                                                "btc": "0",
+                                                "eth": "0",
+                                                "usd": "0",
+                                              },
+                                            },
+                                            "nahmiiActive": Object {
                                               "assets": Array [],
                                               "error": null,
                                               "loading": true,
@@ -14676,6 +16420,16 @@ ShallowWrapper {
                                               "assets": Array [],
                                               "error": null,
                                               "loading": true,
+                                              "total": Object {
+                                                "btc": "0",
+                                                "eth": "0",
+                                                "usd": "0",
+                                              },
+                                            },
+                                            "nahmiiActive": Object {
+                                              "assets": Array [],
+                                              "error": null,
+                                              "loading": false,
                                               "total": Object {
                                                 "btc": "0",
                                                 "eth": "0",
@@ -14852,6 +16606,27 @@ ShallowWrapper {
                                                         error: null,
                                                         total: Immutable.Map {
                                                                 usd: "0",
+                                                        },
+                                                },
+                                                nahmiiActive: Immutable.Map {
+                                                        assets: Immutable.Map {
+                                                                0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                        value: Immutable.Map {
+                                                                                usd: "82.4",
+                                                                        },
+                                                                        amount: "0.2",
+                                                                },
+                                                                0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                        value: Immutable.Map {
+                                                                                usd: "0.13",
+                                                                        },
+                                                                        amount: "0.13",
+                                                                },
+                                                        },
+                                                        loading: false,
+                                                        error: null,
+                                                        total: Immutable.Map {
+                                                                usd: "82.53",
                                                         },
                                                 },
                                                 nahmiiCombined: Immutable.Map {
@@ -15066,6 +16841,37 @@ ShallowWrapper {
                                                         "usd": "164.492044000001231288",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [
+                                                        Object {
+                                                          "balance": "0.2",
+                                                          "currency": "0x0000000000000000000000000000000000000000",
+                                                          "symbol": "ETH",
+                                                          "value": Object {
+                                                            "btc": "0.002",
+                                                            "eth": "0.2",
+                                                            "usd": "82.4",
+                                                          },
+                                                        },
+                                                        Object {
+                                                          "balance": "0.13",
+                                                          "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                          "symbol": "BOKKY",
+                                                          "value": Object {
+                                                            "btc": "0.00013",
+                                                            "eth": "0.013",
+                                                            "usd": "0.13",
+                                                          },
+                                                        },
+                                                      ],
+                                                      "error": null,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0.00213",
+                                                        "eth": "0.213",
+                                                        "usd": "82.53",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [
                                                         Object {
@@ -15188,6 +16994,16 @@ ShallowWrapper {
                                                         "usd": "0",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": true,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [],
                                                       "error": true,
@@ -15247,6 +17063,16 @@ ShallowWrapper {
                                                       },
                                                     },
                                                     "combined": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
@@ -15324,6 +17150,16 @@ ShallowWrapper {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": false,
                                                       "total": Object {
                                                         "btc": "0",
                                                         "eth": "0",
@@ -15500,6 +17336,27 @@ ShallowWrapper {
                                                                         error: null,
                                                                         total: Immutable.Map {
                                                                                     usd: "0",
+                                                                        },
+                                                            },
+                                                            nahmiiActive: Immutable.Map {
+                                                                        assets: Immutable.Map {
+                                                                                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                value: Immutable.Map {
+                                                                                                            usd: "82.4",
+                                                                                                },
+                                                                                                amount: "0.2",
+                                                                                    },
+                                                                                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                value: Immutable.Map {
+                                                                                                            usd: "0.13",
+                                                                                                },
+                                                                                                amount: "0.13",
+                                                                                    },
+                                                                        },
+                                                                        loading: false,
+                                                                        error: null,
+                                                                        total: Immutable.Map {
+                                                                                    usd: "82.53",
                                                                         },
                                                             },
                                                             nahmiiCombined: Immutable.Map {
@@ -15714,6 +17571,37 @@ ShallowWrapper {
                                                         "usd": "164.492044000001231288",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [
+                                                        Object {
+                                                          "balance": "0.2",
+                                                          "currency": "0x0000000000000000000000000000000000000000",
+                                                          "symbol": "ETH",
+                                                          "value": Object {
+                                                            "btc": "0.002",
+                                                            "eth": "0.2",
+                                                            "usd": "82.4",
+                                                          },
+                                                        },
+                                                        Object {
+                                                          "balance": "0.13",
+                                                          "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                          "symbol": "BOKKY",
+                                                          "value": Object {
+                                                            "btc": "0.00013",
+                                                            "eth": "0.013",
+                                                            "usd": "0.13",
+                                                          },
+                                                        },
+                                                      ],
+                                                      "error": null,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0.00213",
+                                                        "eth": "0.213",
+                                                        "usd": "82.53",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [
                                                         Object {
@@ -15836,6 +17724,16 @@ ShallowWrapper {
                                                         "usd": "0",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": true,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [],
                                                       "error": true,
@@ -15895,6 +17793,16 @@ ShallowWrapper {
                                                       },
                                                     },
                                                     "combined": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
@@ -15972,6 +17880,16 @@ ShallowWrapper {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": false,
                                                       "total": Object {
                                                         "btc": "0",
                                                         "eth": "0",
@@ -16190,6 +18108,37 @@ ShallowWrapper {
                           "usd": "164.492044000001231288",
                         },
                       },
+                      "nahmiiActive": Object {
+                        "assets": Array [
+                          Object {
+                            "balance": "0.2",
+                            "currency": "0x0000000000000000000000000000000000000000",
+                            "symbol": "ETH",
+                            "value": Object {
+                              "btc": "0.002",
+                              "eth": "0.2",
+                              "usd": "82.4",
+                            },
+                          },
+                          Object {
+                            "balance": "0.13",
+                            "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            "symbol": "BOKKY",
+                            "value": Object {
+                              "btc": "0.00013",
+                              "eth": "0.013",
+                              "usd": "0.13",
+                            },
+                          },
+                        ],
+                        "error": null,
+                        "loading": false,
+                        "total": Object {
+                          "btc": "0.00213",
+                          "eth": "0.213",
+                          "usd": "82.53",
+                        },
+                      },
                       "nahmiiAvailable": Object {
                         "assets": Array [
                           Object {
@@ -16312,6 +18261,16 @@ ShallowWrapper {
                           "usd": "0",
                         },
                       },
+                      "nahmiiActive": Object {
+                        "assets": Array [],
+                        "error": true,
+                        "loading": false,
+                        "total": Object {
+                          "btc": "0",
+                          "eth": "0",
+                          "usd": "0",
+                        },
+                      },
                       "nahmiiAvailable": Object {
                         "assets": Array [],
                         "error": true,
@@ -16371,6 +18330,16 @@ ShallowWrapper {
                         },
                       },
                       "combined": Object {
+                        "assets": Array [],
+                        "error": null,
+                        "loading": true,
+                        "total": Object {
+                          "btc": "0",
+                          "eth": "0",
+                          "usd": "0",
+                        },
+                      },
+                      "nahmiiActive": Object {
                         "assets": Array [],
                         "error": null,
                         "loading": true,
@@ -16448,6 +18417,16 @@ ShallowWrapper {
                         "assets": Array [],
                         "error": null,
                         "loading": true,
+                        "total": Object {
+                          "btc": "0",
+                          "eth": "0",
+                          "usd": "0",
+                        },
+                      },
+                      "nahmiiActive": Object {
+                        "assets": Array [],
+                        "error": null,
+                        "loading": false,
                         "total": Object {
                           "btc": "0",
                           "eth": "0",
@@ -16631,6 +18610,27 @@ ShallowWrapper {
                                                                                     usd: "0",
                                                                       },
                                                         },
+                                                        nahmiiActive: Immutable.Map {
+                                                                      assets: Immutable.Map {
+                                                                                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                  value: Immutable.Map {
+                                                                                                                usd: "82.4",
+                                                                                                  },
+                                                                                                  amount: "0.2",
+                                                                                    },
+                                                                                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                  value: Immutable.Map {
+                                                                                                                usd: "0.13",
+                                                                                                  },
+                                                                                                  amount: "0.13",
+                                                                                    },
+                                                                      },
+                                                                      loading: false,
+                                                                      error: null,
+                                                                      total: Immutable.Map {
+                                                                                    usd: "82.53",
+                                                                      },
+                                                        },
                                                         nahmiiCombined: Immutable.Map {
                                                                       assets: Immutable.Map {
                                                                                     0x0000000000000000000000000000000000000000: Immutable.Map {
@@ -16802,6 +18802,27 @@ ShallowWrapper {
                                                                         error: null,
                                                                         total: Immutable.Map {
                                                                                           usd: "0",
+                                                                        },
+                                                      },
+                                                      nahmiiActive: Immutable.Map {
+                                                                        assets: Immutable.Map {
+                                                                                          0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                            value: Immutable.Map {
+                                                                                                                              usd: "82.4",
+                                                                                                            },
+                                                                                                            amount: "0.2",
+                                                                                          },
+                                                                                          0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                            value: Immutable.Map {
+                                                                                                                              usd: "0.13",
+                                                                                                            },
+                                                                                                            amount: "0.13",
+                                                                                          },
+                                                                        },
+                                                                        loading: false,
+                                                                        error: null,
+                                                                        total: Immutable.Map {
+                                                                                          usd: "82.53",
                                                                         },
                                                       },
                                                       nahmiiCombined: Immutable.Map {
@@ -16976,6 +18997,27 @@ ShallowWrapper {
                                         error: null,
                                         total: Immutable.Map {
                                                             usd: "0",
+                                        },
+                    },
+                    nahmiiActive: Immutable.Map {
+                                        assets: Immutable.Map {
+                                                            0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                value: Immutable.Map {
+                                                                                                    usd: "82.4",
+                                                                                },
+                                                                                amount: "0.2",
+                                                            },
+                                                            0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                value: Immutable.Map {
+                                                                                                    usd: "0.13",
+                                                                                },
+                                                                                amount: "0.13",
+                                                            },
+                                        },
+                                        loading: false,
+                                        error: null,
+                                        total: Immutable.Map {
+                                                            usd: "82.53",
                                         },
                     },
                     nahmiiCombined: Immutable.Map {
@@ -17206,6 +19248,37 @@ ShallowWrapper {
                                                           "usd": "164.492044000001231288",
                                                         },
                                                       },
+                                                      "nahmiiActive": Object {
+                                                        "assets": Array [
+                                                          Object {
+                                                            "balance": "0.2",
+                                                            "currency": "0x0000000000000000000000000000000000000000",
+                                                            "symbol": "ETH",
+                                                            "value": Object {
+                                                              "btc": "0.002",
+                                                              "eth": "0.2",
+                                                              "usd": "82.4",
+                                                            },
+                                                          },
+                                                          Object {
+                                                            "balance": "0.13",
+                                                            "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                            "symbol": "BOKKY",
+                                                            "value": Object {
+                                                              "btc": "0.00013",
+                                                              "eth": "0.013",
+                                                              "usd": "0.13",
+                                                            },
+                                                          },
+                                                        ],
+                                                        "error": null,
+                                                        "loading": false,
+                                                        "total": Object {
+                                                          "btc": "0.00213",
+                                                          "eth": "0.213",
+                                                          "usd": "82.53",
+                                                        },
+                                                      },
                                                       "nahmiiAvailable": Object {
                                                         "assets": Array [
                                                           Object {
@@ -17328,6 +19401,16 @@ ShallowWrapper {
                                                           "usd": "0",
                                                         },
                                                       },
+                                                      "nahmiiActive": Object {
+                                                        "assets": Array [],
+                                                        "error": true,
+                                                        "loading": false,
+                                                        "total": Object {
+                                                          "btc": "0",
+                                                          "eth": "0",
+                                                          "usd": "0",
+                                                        },
+                                                      },
                                                       "nahmiiAvailable": Object {
                                                         "assets": Array [],
                                                         "error": true,
@@ -17387,6 +19470,16 @@ ShallowWrapper {
                                                         },
                                                       },
                                                       "combined": Object {
+                                                        "assets": Array [],
+                                                        "error": null,
+                                                        "loading": true,
+                                                        "total": Object {
+                                                          "btc": "0",
+                                                          "eth": "0",
+                                                          "usd": "0",
+                                                        },
+                                                      },
+                                                      "nahmiiActive": Object {
                                                         "assets": Array [],
                                                         "error": null,
                                                         "loading": true,
@@ -17464,6 +19557,16 @@ ShallowWrapper {
                                                         "assets": Array [],
                                                         "error": null,
                                                         "loading": true,
+                                                        "total": Object {
+                                                          "btc": "0",
+                                                          "eth": "0",
+                                                          "usd": "0",
+                                                        },
+                                                      },
+                                                      "nahmiiActive": Object {
+                                                        "assets": Array [],
+                                                        "error": null,
+                                                        "loading": false,
                                                         "total": Object {
                                                           "btc": "0",
                                                           "eth": "0",
@@ -17640,6 +19743,27 @@ ShallowWrapper {
                                                                       error: null,
                                                                       total: Immutable.Map {
                                                                                 usd: "0",
+                                                                      },
+                                                            },
+                                                            nahmiiActive: Immutable.Map {
+                                                                      assets: Immutable.Map {
+                                                                                0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                          value: Immutable.Map {
+                                                                                                    usd: "82.4",
+                                                                                          },
+                                                                                          amount: "0.2",
+                                                                                },
+                                                                                0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                          value: Immutable.Map {
+                                                                                                    usd: "0.13",
+                                                                                          },
+                                                                                          amount: "0.13",
+                                                                                },
+                                                                      },
+                                                                      loading: false,
+                                                                      error: null,
+                                                                      total: Immutable.Map {
+                                                                                usd: "82.53",
                                                                       },
                                                             },
                                                             nahmiiCombined: Immutable.Map {
@@ -17854,6 +19978,37 @@ ShallowWrapper {
                                                                 "usd": "164.492044000001231288",
                                                               },
                                                             },
+                                                            "nahmiiActive": Object {
+                                                              "assets": Array [
+                                                                Object {
+                                                                  "balance": "0.2",
+                                                                  "currency": "0x0000000000000000000000000000000000000000",
+                                                                  "symbol": "ETH",
+                                                                  "value": Object {
+                                                                    "btc": "0.002",
+                                                                    "eth": "0.2",
+                                                                    "usd": "82.4",
+                                                                  },
+                                                                },
+                                                                Object {
+                                                                  "balance": "0.13",
+                                                                  "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                  "symbol": "BOKKY",
+                                                                  "value": Object {
+                                                                    "btc": "0.00013",
+                                                                    "eth": "0.013",
+                                                                    "usd": "0.13",
+                                                                  },
+                                                                },
+                                                              ],
+                                                              "error": null,
+                                                              "loading": false,
+                                                              "total": Object {
+                                                                "btc": "0.00213",
+                                                                "eth": "0.213",
+                                                                "usd": "82.53",
+                                                              },
+                                                            },
                                                             "nahmiiAvailable": Object {
                                                               "assets": Array [
                                                                 Object {
@@ -17976,6 +20131,16 @@ ShallowWrapper {
                                                                 "usd": "0",
                                                               },
                                                             },
+                                                            "nahmiiActive": Object {
+                                                              "assets": Array [],
+                                                              "error": true,
+                                                              "loading": false,
+                                                              "total": Object {
+                                                                "btc": "0",
+                                                                "eth": "0",
+                                                                "usd": "0",
+                                                              },
+                                                            },
                                                             "nahmiiAvailable": Object {
                                                               "assets": Array [],
                                                               "error": true,
@@ -18035,6 +20200,16 @@ ShallowWrapper {
                                                               },
                                                             },
                                                             "combined": Object {
+                                                              "assets": Array [],
+                                                              "error": null,
+                                                              "loading": true,
+                                                              "total": Object {
+                                                                "btc": "0",
+                                                                "eth": "0",
+                                                                "usd": "0",
+                                                              },
+                                                            },
+                                                            "nahmiiActive": Object {
                                                               "assets": Array [],
                                                               "error": null,
                                                               "loading": true,
@@ -18112,6 +20287,16 @@ ShallowWrapper {
                                                               "assets": Array [],
                                                               "error": null,
                                                               "loading": true,
+                                                              "total": Object {
+                                                                "btc": "0",
+                                                                "eth": "0",
+                                                                "usd": "0",
+                                                              },
+                                                            },
+                                                            "nahmiiActive": Object {
+                                                              "assets": Array [],
+                                                              "error": null,
+                                                              "loading": false,
                                                               "total": Object {
                                                                 "btc": "0",
                                                                 "eth": "0",
@@ -18288,6 +20473,27 @@ ShallowWrapper {
                                                                                     error: null,
                                                                                     total: Immutable.Map {
                                                                                                   usd: "0",
+                                                                                    },
+                                                                      },
+                                                                      nahmiiActive: Immutable.Map {
+                                                                                    assets: Immutable.Map {
+                                                                                                  0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                                value: Immutable.Map {
+                                                                                                                              usd: "82.4",
+                                                                                                                },
+                                                                                                                amount: "0.2",
+                                                                                                  },
+                                                                                                  0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                                value: Immutable.Map {
+                                                                                                                              usd: "0.13",
+                                                                                                                },
+                                                                                                                amount: "0.13",
+                                                                                                  },
+                                                                                    },
+                                                                                    loading: false,
+                                                                                    error: null,
+                                                                                    total: Immutable.Map {
+                                                                                                  usd: "82.53",
                                                                                     },
                                                                       },
                                                                       nahmiiCombined: Immutable.Map {
@@ -18502,6 +20708,37 @@ ShallowWrapper {
                                                               "usd": "164.492044000001231288",
                                                             },
                                                           },
+                                                          "nahmiiActive": Object {
+                                                            "assets": Array [
+                                                              Object {
+                                                                "balance": "0.2",
+                                                                "currency": "0x0000000000000000000000000000000000000000",
+                                                                "symbol": "ETH",
+                                                                "value": Object {
+                                                                  "btc": "0.002",
+                                                                  "eth": "0.2",
+                                                                  "usd": "82.4",
+                                                                },
+                                                              },
+                                                              Object {
+                                                                "balance": "0.13",
+                                                                "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                "symbol": "BOKKY",
+                                                                "value": Object {
+                                                                  "btc": "0.00013",
+                                                                  "eth": "0.013",
+                                                                  "usd": "0.13",
+                                                                },
+                                                              },
+                                                            ],
+                                                            "error": null,
+                                                            "loading": false,
+                                                            "total": Object {
+                                                              "btc": "0.00213",
+                                                              "eth": "0.213",
+                                                              "usd": "82.53",
+                                                            },
+                                                          },
                                                           "nahmiiAvailable": Object {
                                                             "assets": Array [
                                                               Object {
@@ -18624,6 +20861,16 @@ ShallowWrapper {
                                                               "usd": "0",
                                                             },
                                                           },
+                                                          "nahmiiActive": Object {
+                                                            "assets": Array [],
+                                                            "error": true,
+                                                            "loading": false,
+                                                            "total": Object {
+                                                              "btc": "0",
+                                                              "eth": "0",
+                                                              "usd": "0",
+                                                            },
+                                                          },
                                                           "nahmiiAvailable": Object {
                                                             "assets": Array [],
                                                             "error": true,
@@ -18683,6 +20930,16 @@ ShallowWrapper {
                                                             },
                                                           },
                                                           "combined": Object {
+                                                            "assets": Array [],
+                                                            "error": null,
+                                                            "loading": true,
+                                                            "total": Object {
+                                                              "btc": "0",
+                                                              "eth": "0",
+                                                              "usd": "0",
+                                                            },
+                                                          },
+                                                          "nahmiiActive": Object {
                                                             "assets": Array [],
                                                             "error": null,
                                                             "loading": true,
@@ -18760,6 +21017,16 @@ ShallowWrapper {
                                                             "assets": Array [],
                                                             "error": null,
                                                             "loading": true,
+                                                            "total": Object {
+                                                              "btc": "0",
+                                                              "eth": "0",
+                                                              "usd": "0",
+                                                            },
+                                                          },
+                                                          "nahmiiActive": Object {
+                                                            "assets": Array [],
+                                                            "error": null,
+                                                            "loading": false,
                                                             "total": Object {
                                                               "btc": "0",
                                                               "eth": "0",
@@ -18978,6 +21245,37 @@ ShallowWrapper {
                             "usd": "164.492044000001231288",
                           },
                         },
+                        "nahmiiActive": Object {
+                          "assets": Array [
+                            Object {
+                              "balance": "0.2",
+                              "currency": "0x0000000000000000000000000000000000000000",
+                              "symbol": "ETH",
+                              "value": Object {
+                                "btc": "0.002",
+                                "eth": "0.2",
+                                "usd": "82.4",
+                              },
+                            },
+                            Object {
+                              "balance": "0.13",
+                              "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                              "symbol": "BOKKY",
+                              "value": Object {
+                                "btc": "0.00013",
+                                "eth": "0.013",
+                                "usd": "0.13",
+                              },
+                            },
+                          ],
+                          "error": null,
+                          "loading": false,
+                          "total": Object {
+                            "btc": "0.00213",
+                            "eth": "0.213",
+                            "usd": "82.53",
+                          },
+                        },
                         "nahmiiAvailable": Object {
                           "assets": Array [
                             Object {
@@ -19100,6 +21398,16 @@ ShallowWrapper {
                             "usd": "0",
                           },
                         },
+                        "nahmiiActive": Object {
+                          "assets": Array [],
+                          "error": true,
+                          "loading": false,
+                          "total": Object {
+                            "btc": "0",
+                            "eth": "0",
+                            "usd": "0",
+                          },
+                        },
                         "nahmiiAvailable": Object {
                           "assets": Array [],
                           "error": true,
@@ -19159,6 +21467,16 @@ ShallowWrapper {
                           },
                         },
                         "combined": Object {
+                          "assets": Array [],
+                          "error": null,
+                          "loading": true,
+                          "total": Object {
+                            "btc": "0",
+                            "eth": "0",
+                            "usd": "0",
+                          },
+                        },
+                        "nahmiiActive": Object {
                           "assets": Array [],
                           "error": null,
                           "loading": true,
@@ -19236,6 +21554,16 @@ ShallowWrapper {
                           "assets": Array [],
                           "error": null,
                           "loading": true,
+                          "total": Object {
+                            "btc": "0",
+                            "eth": "0",
+                            "usd": "0",
+                          },
+                        },
+                        "nahmiiActive": Object {
+                          "assets": Array [],
+                          "error": null,
+                          "loading": false,
                           "total": Object {
                             "btc": "0",
                             "eth": "0",
@@ -19419,6 +21747,27 @@ ShallowWrapper {
                                                                                                 usd: "0",
                                                                                 },
                                                                 },
+                                                                nahmiiActive: Immutable.Map {
+                                                                                assets: Immutable.Map {
+                                                                                                0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                                value: Immutable.Map {
+                                                                                                                                usd: "82.4",
+                                                                                                                },
+                                                                                                                amount: "0.2",
+                                                                                                },
+                                                                                                0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                                value: Immutable.Map {
+                                                                                                                                usd: "0.13",
+                                                                                                                },
+                                                                                                                amount: "0.13",
+                                                                                                },
+                                                                                },
+                                                                                loading: false,
+                                                                                error: null,
+                                                                                total: Immutable.Map {
+                                                                                                usd: "82.53",
+                                                                                },
+                                                                },
                                                                 nahmiiCombined: Immutable.Map {
                                                                                 assets: Immutable.Map {
                                                                                                 0x0000000000000000000000000000000000000000: Immutable.Map {
@@ -19590,6 +21939,27 @@ ShallowWrapper {
                                                                                 error: null,
                                                                                 total: Immutable.Map {
                                                                                                     usd: "0",
+                                                                                },
+                                                            },
+                                                            nahmiiActive: Immutable.Map {
+                                                                                assets: Immutable.Map {
+                                                                                                    0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                                                        value: Immutable.Map {
+                                                                                                                                            usd: "82.4",
+                                                                                                                        },
+                                                                                                                        amount: "0.2",
+                                                                                                    },
+                                                                                                    0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                                                        value: Immutable.Map {
+                                                                                                                                            usd: "0.13",
+                                                                                                                        },
+                                                                                                                        amount: "0.13",
+                                                                                                    },
+                                                                                },
+                                                                                loading: false,
+                                                                                error: null,
+                                                                                total: Immutable.Map {
+                                                                                                    usd: "82.53",
                                                                                 },
                                                             },
                                                             nahmiiCombined: Immutable.Map {
@@ -19764,6 +22134,27 @@ ShallowWrapper {
                                             error: null,
                                             total: Immutable.Map {
                                                                   usd: "0",
+                                            },
+                      },
+                      nahmiiActive: Immutable.Map {
+                                            assets: Immutable.Map {
+                                                                  0x0000000000000000000000000000000000000000: Immutable.Map {
+                                                                                        value: Immutable.Map {
+                                                                                                              usd: "82.4",
+                                                                                        },
+                                                                                        amount: "0.2",
+                                                                  },
+                                                                  0x583cbbb8a8443b38abcc0c956bece47340ea1367: Immutable.Map {
+                                                                                        value: Immutable.Map {
+                                                                                                              usd: "0.13",
+                                                                                        },
+                                                                                        amount: "0.13",
+                                                                  },
+                                            },
+                                            loading: false,
+                                            error: null,
+                                            total: Immutable.Map {
+                                                                  usd: "82.53",
                                             },
                       },
                       nahmiiCombined: Immutable.Map {
@@ -19995,6 +22386,15 @@ ShallowWrapper {
                     usd: "0",
                 },
             },
+            nahmiiActive: Immutable.Map {
+                assets: Immutable.Map {
+                },
+                loading: false,
+                error: null,
+                total: Immutable.Map {
+                    usd: "0",
+                },
+            },
             nahmiiCombined: Immutable.Map {
                 assets: Immutable.Map {
                 },
@@ -20190,6 +22590,37 @@ ShallowWrapper {
                             usd: "82.53",
                         },
                     },
+                    nahmiiActive: Immutable.Map {
+                        loading: false,
+                        error: null,
+                        assets: Immutable.List [
+                            Immutable.Map {
+                                currency: "0x0000000000000000000000000000000000000000",
+                                balance: "0.2",
+                                symbol: "ETH",
+                                value: Immutable.Map {
+                                    eth: "0.2",
+                                    btc: "0.002",
+                                    usd: "82.4",
+                                },
+                            },
+                            Immutable.Map {
+                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                balance: "0.13",
+                                symbol: "BOKKY",
+                                value: Immutable.Map {
+                                    eth: "0.013",
+                                    btc: "0.00013",
+                                    usd: "0.13",
+                                },
+                            },
+                        ],
+                        total: Immutable.Map {
+                            eth: "0.213",
+                            btc: "0.00213",
+                            usd: "82.53",
+                        },
+                    },
                     combined: Immutable.Map {
                         loading: false,
                         error: null,
@@ -20284,6 +22715,17 @@ ShallowWrapper {
                             usd: "0",
                         },
                     },
+                    nahmiiActive: Immutable.Map {
+                        loading: false,
+                        error: true,
+                        assets: Immutable.List [
+                        ],
+                        total: Immutable.Map {
+                            eth: "0",
+                            btc: "0",
+                            usd: "0",
+                        },
+                    },
                     combined: Immutable.Map {
                         loading: false,
                         error: true,
@@ -20364,6 +22806,17 @@ ShallowWrapper {
                             usd: "0",
                         },
                     },
+                    nahmiiActive: Immutable.Map {
+                        loading: true,
+                        error: null,
+                        assets: Immutable.List [
+                        ],
+                        total: Immutable.Map {
+                            eth: "0",
+                            btc: "0",
+                            usd: "0",
+                        },
+                    },
                     combined: Immutable.Map {
                         loading: true,
                         error: null,
@@ -20429,6 +22882,17 @@ ShallowWrapper {
                         },
                     },
                     nahmiiCombined: Immutable.Map {
+                        loading: false,
+                        error: null,
+                        assets: Immutable.List [
+                        ],
+                        total: Immutable.Map {
+                            eth: "0",
+                            btc: "0",
+                            usd: "0",
+                        },
+                    },
+                    nahmiiActive: Immutable.Map {
                         loading: false,
                         error: null,
                         assets: Immutable.List [
@@ -20631,6 +23095,37 @@ ShallowWrapper {
                                                 "usd": "164.492044000001231288",
                                               },
                                             },
+                                            "nahmiiActive": Object {
+                                              "assets": Array [
+                                                Object {
+                                                  "balance": "0.2",
+                                                  "currency": "0x0000000000000000000000000000000000000000",
+                                                  "symbol": "ETH",
+                                                  "value": Object {
+                                                    "btc": "0.002",
+                                                    "eth": "0.2",
+                                                    "usd": "82.4",
+                                                  },
+                                                },
+                                                Object {
+                                                  "balance": "0.13",
+                                                  "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                  "symbol": "BOKKY",
+                                                  "value": Object {
+                                                    "btc": "0.00013",
+                                                    "eth": "0.013",
+                                                    "usd": "0.13",
+                                                  },
+                                                },
+                                              ],
+                                              "error": null,
+                                              "loading": false,
+                                              "total": Object {
+                                                "btc": "0.00213",
+                                                "eth": "0.213",
+                                                "usd": "82.53",
+                                              },
+                                            },
                                             "nahmiiAvailable": Object {
                                               "assets": Array [
                                                 Object {
@@ -20753,6 +23248,16 @@ ShallowWrapper {
                                                 "usd": "0",
                                               },
                                             },
+                                            "nahmiiActive": Object {
+                                              "assets": Array [],
+                                              "error": true,
+                                              "loading": false,
+                                              "total": Object {
+                                                "btc": "0",
+                                                "eth": "0",
+                                                "usd": "0",
+                                              },
+                                            },
                                             "nahmiiAvailable": Object {
                                               "assets": Array [],
                                               "error": true,
@@ -20812,6 +23317,16 @@ ShallowWrapper {
                                               },
                                             },
                                             "combined": Object {
+                                              "assets": Array [],
+                                              "error": null,
+                                              "loading": true,
+                                              "total": Object {
+                                                "btc": "0",
+                                                "eth": "0",
+                                                "usd": "0",
+                                              },
+                                            },
+                                            "nahmiiActive": Object {
                                               "assets": Array [],
                                               "error": null,
                                               "loading": true,
@@ -20889,6 +23404,16 @@ ShallowWrapper {
                                               "assets": Array [],
                                               "error": null,
                                               "loading": true,
+                                              "total": Object {
+                                                "btc": "0",
+                                                "eth": "0",
+                                                "usd": "0",
+                                              },
+                                            },
+                                            "nahmiiActive": Object {
+                                              "assets": Array [],
+                                              "error": null,
+                                              "loading": false,
                                               "total": Object {
                                                 "btc": "0",
                                                 "eth": "0",
@@ -21033,6 +23558,15 @@ ShallowWrapper {
                                                         },
                                                         loading: false,
                                                         error: true,
+                                                        total: Immutable.Map {
+                                                                usd: "0",
+                                                        },
+                                                },
+                                                nahmiiActive: Immutable.Map {
+                                                        assets: Immutable.Map {
+                                                        },
+                                                        loading: false,
+                                                        error: null,
                                                         total: Immutable.Map {
                                                                 usd: "0",
                                                         },
@@ -21225,6 +23759,37 @@ ShallowWrapper {
                                                         "usd": "164.492044000001231288",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [
+                                                        Object {
+                                                          "balance": "0.2",
+                                                          "currency": "0x0000000000000000000000000000000000000000",
+                                                          "symbol": "ETH",
+                                                          "value": Object {
+                                                            "btc": "0.002",
+                                                            "eth": "0.2",
+                                                            "usd": "82.4",
+                                                          },
+                                                        },
+                                                        Object {
+                                                          "balance": "0.13",
+                                                          "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                          "symbol": "BOKKY",
+                                                          "value": Object {
+                                                            "btc": "0.00013",
+                                                            "eth": "0.013",
+                                                            "usd": "0.13",
+                                                          },
+                                                        },
+                                                      ],
+                                                      "error": null,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0.00213",
+                                                        "eth": "0.213",
+                                                        "usd": "82.53",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [
                                                         Object {
@@ -21347,6 +23912,16 @@ ShallowWrapper {
                                                         "usd": "0",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": true,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [],
                                                       "error": true,
@@ -21406,6 +23981,16 @@ ShallowWrapper {
                                                       },
                                                     },
                                                     "combined": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
@@ -21483,6 +24068,16 @@ ShallowWrapper {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": false,
                                                       "total": Object {
                                                         "btc": "0",
                                                         "eth": "0",
@@ -21627,6 +24222,15 @@ ShallowWrapper {
                                                                         },
                                                                         loading: false,
                                                                         error: true,
+                                                                        total: Immutable.Map {
+                                                                                    usd: "0",
+                                                                        },
+                                                            },
+                                                            nahmiiActive: Immutable.Map {
+                                                                        assets: Immutable.Map {
+                                                                        },
+                                                                        loading: false,
+                                                                        error: null,
                                                                         total: Immutable.Map {
                                                                                     usd: "0",
                                                                         },
@@ -21819,6 +24423,37 @@ ShallowWrapper {
                                                         "usd": "164.492044000001231288",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [
+                                                        Object {
+                                                          "balance": "0.2",
+                                                          "currency": "0x0000000000000000000000000000000000000000",
+                                                          "symbol": "ETH",
+                                                          "value": Object {
+                                                            "btc": "0.002",
+                                                            "eth": "0.2",
+                                                            "usd": "82.4",
+                                                          },
+                                                        },
+                                                        Object {
+                                                          "balance": "0.13",
+                                                          "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                          "symbol": "BOKKY",
+                                                          "value": Object {
+                                                            "btc": "0.00013",
+                                                            "eth": "0.013",
+                                                            "usd": "0.13",
+                                                          },
+                                                        },
+                                                      ],
+                                                      "error": null,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0.00213",
+                                                        "eth": "0.213",
+                                                        "usd": "82.53",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [
                                                         Object {
@@ -21941,6 +24576,16 @@ ShallowWrapper {
                                                         "usd": "0",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": true,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [],
                                                       "error": true,
@@ -22000,6 +24645,16 @@ ShallowWrapper {
                                                       },
                                                     },
                                                     "combined": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
@@ -22077,6 +24732,16 @@ ShallowWrapper {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": false,
                                                       "total": Object {
                                                         "btc": "0",
                                                         "eth": "0",
@@ -22295,6 +24960,37 @@ ShallowWrapper {
                           "usd": "164.492044000001231288",
                         },
                       },
+                      "nahmiiActive": Object {
+                        "assets": Array [
+                          Object {
+                            "balance": "0.2",
+                            "currency": "0x0000000000000000000000000000000000000000",
+                            "symbol": "ETH",
+                            "value": Object {
+                              "btc": "0.002",
+                              "eth": "0.2",
+                              "usd": "82.4",
+                            },
+                          },
+                          Object {
+                            "balance": "0.13",
+                            "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            "symbol": "BOKKY",
+                            "value": Object {
+                              "btc": "0.00013",
+                              "eth": "0.013",
+                              "usd": "0.13",
+                            },
+                          },
+                        ],
+                        "error": null,
+                        "loading": false,
+                        "total": Object {
+                          "btc": "0.00213",
+                          "eth": "0.213",
+                          "usd": "82.53",
+                        },
+                      },
                       "nahmiiAvailable": Object {
                         "assets": Array [
                           Object {
@@ -22417,6 +25113,16 @@ ShallowWrapper {
                           "usd": "0",
                         },
                       },
+                      "nahmiiActive": Object {
+                        "assets": Array [],
+                        "error": true,
+                        "loading": false,
+                        "total": Object {
+                          "btc": "0",
+                          "eth": "0",
+                          "usd": "0",
+                        },
+                      },
                       "nahmiiAvailable": Object {
                         "assets": Array [],
                         "error": true,
@@ -22476,6 +25182,16 @@ ShallowWrapper {
                         },
                       },
                       "combined": Object {
+                        "assets": Array [],
+                        "error": null,
+                        "loading": true,
+                        "total": Object {
+                          "btc": "0",
+                          "eth": "0",
+                          "usd": "0",
+                        },
+                      },
+                      "nahmiiActive": Object {
                         "assets": Array [],
                         "error": null,
                         "loading": true,
@@ -22553,6 +25269,16 @@ ShallowWrapper {
                         "assets": Array [],
                         "error": null,
                         "loading": true,
+                        "total": Object {
+                          "btc": "0",
+                          "eth": "0",
+                          "usd": "0",
+                        },
+                      },
+                      "nahmiiActive": Object {
+                        "assets": Array [],
+                        "error": null,
+                        "loading": false,
                         "total": Object {
                           "btc": "0",
                           "eth": "0",
@@ -22706,6 +25432,15 @@ ShallowWrapper {
                                                                                     usd: "0",
                                                                       },
                                                         },
+                                                        nahmiiActive: Immutable.Map {
+                                                                      assets: Immutable.Map {
+                                                                      },
+                                                                      loading: false,
+                                                                      error: null,
+                                                                      total: Immutable.Map {
+                                                                                    usd: "0",
+                                                                      },
+                                                        },
                                                         nahmiiCombined: Immutable.Map {
                                                                       assets: Immutable.Map {
                                                                       },
@@ -22821,6 +25556,15 @@ ShallowWrapper {
                                                                         },
                                                                         loading: false,
                                                                         error: true,
+                                                                        total: Immutable.Map {
+                                                                                          usd: "0",
+                                                                        },
+                                                      },
+                                                      nahmiiActive: Immutable.Map {
+                                                                        assets: Immutable.Map {
+                                                                        },
+                                                                        loading: false,
+                                                                        error: null,
                                                                         total: Immutable.Map {
                                                                                           usd: "0",
                                                                         },
@@ -22941,6 +25685,15 @@ ShallowWrapper {
                                         },
                                         loading: false,
                                         error: true,
+                                        total: Immutable.Map {
+                                                            usd: "0",
+                                        },
+                    },
+                    nahmiiActive: Immutable.Map {
+                                        assets: Immutable.Map {
+                                        },
+                                        loading: false,
+                                        error: null,
                                         total: Immutable.Map {
                                                             usd: "0",
                                         },
@@ -23149,6 +25902,37 @@ ShallowWrapper {
                                                           "usd": "164.492044000001231288",
                                                         },
                                                       },
+                                                      "nahmiiActive": Object {
+                                                        "assets": Array [
+                                                          Object {
+                                                            "balance": "0.2",
+                                                            "currency": "0x0000000000000000000000000000000000000000",
+                                                            "symbol": "ETH",
+                                                            "value": Object {
+                                                              "btc": "0.002",
+                                                              "eth": "0.2",
+                                                              "usd": "82.4",
+                                                            },
+                                                          },
+                                                          Object {
+                                                            "balance": "0.13",
+                                                            "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                            "symbol": "BOKKY",
+                                                            "value": Object {
+                                                              "btc": "0.00013",
+                                                              "eth": "0.013",
+                                                              "usd": "0.13",
+                                                            },
+                                                          },
+                                                        ],
+                                                        "error": null,
+                                                        "loading": false,
+                                                        "total": Object {
+                                                          "btc": "0.00213",
+                                                          "eth": "0.213",
+                                                          "usd": "82.53",
+                                                        },
+                                                      },
                                                       "nahmiiAvailable": Object {
                                                         "assets": Array [
                                                           Object {
@@ -23271,6 +26055,16 @@ ShallowWrapper {
                                                           "usd": "0",
                                                         },
                                                       },
+                                                      "nahmiiActive": Object {
+                                                        "assets": Array [],
+                                                        "error": true,
+                                                        "loading": false,
+                                                        "total": Object {
+                                                          "btc": "0",
+                                                          "eth": "0",
+                                                          "usd": "0",
+                                                        },
+                                                      },
                                                       "nahmiiAvailable": Object {
                                                         "assets": Array [],
                                                         "error": true,
@@ -23330,6 +26124,16 @@ ShallowWrapper {
                                                         },
                                                       },
                                                       "combined": Object {
+                                                        "assets": Array [],
+                                                        "error": null,
+                                                        "loading": true,
+                                                        "total": Object {
+                                                          "btc": "0",
+                                                          "eth": "0",
+                                                          "usd": "0",
+                                                        },
+                                                      },
+                                                      "nahmiiActive": Object {
                                                         "assets": Array [],
                                                         "error": null,
                                                         "loading": true,
@@ -23407,6 +26211,16 @@ ShallowWrapper {
                                                         "assets": Array [],
                                                         "error": null,
                                                         "loading": true,
+                                                        "total": Object {
+                                                          "btc": "0",
+                                                          "eth": "0",
+                                                          "usd": "0",
+                                                        },
+                                                      },
+                                                      "nahmiiActive": Object {
+                                                        "assets": Array [],
+                                                        "error": null,
+                                                        "loading": false,
                                                         "total": Object {
                                                           "btc": "0",
                                                           "eth": "0",
@@ -23551,6 +26365,15 @@ ShallowWrapper {
                                                                       },
                                                                       loading: false,
                                                                       error: true,
+                                                                      total: Immutable.Map {
+                                                                                usd: "0",
+                                                                      },
+                                                            },
+                                                            nahmiiActive: Immutable.Map {
+                                                                      assets: Immutable.Map {
+                                                                      },
+                                                                      loading: false,
+                                                                      error: null,
                                                                       total: Immutable.Map {
                                                                                 usd: "0",
                                                                       },
@@ -23743,6 +26566,37 @@ ShallowWrapper {
                                                                 "usd": "164.492044000001231288",
                                                               },
                                                             },
+                                                            "nahmiiActive": Object {
+                                                              "assets": Array [
+                                                                Object {
+                                                                  "balance": "0.2",
+                                                                  "currency": "0x0000000000000000000000000000000000000000",
+                                                                  "symbol": "ETH",
+                                                                  "value": Object {
+                                                                    "btc": "0.002",
+                                                                    "eth": "0.2",
+                                                                    "usd": "82.4",
+                                                                  },
+                                                                },
+                                                                Object {
+                                                                  "balance": "0.13",
+                                                                  "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                  "symbol": "BOKKY",
+                                                                  "value": Object {
+                                                                    "btc": "0.00013",
+                                                                    "eth": "0.013",
+                                                                    "usd": "0.13",
+                                                                  },
+                                                                },
+                                                              ],
+                                                              "error": null,
+                                                              "loading": false,
+                                                              "total": Object {
+                                                                "btc": "0.00213",
+                                                                "eth": "0.213",
+                                                                "usd": "82.53",
+                                                              },
+                                                            },
                                                             "nahmiiAvailable": Object {
                                                               "assets": Array [
                                                                 Object {
@@ -23865,6 +26719,16 @@ ShallowWrapper {
                                                                 "usd": "0",
                                                               },
                                                             },
+                                                            "nahmiiActive": Object {
+                                                              "assets": Array [],
+                                                              "error": true,
+                                                              "loading": false,
+                                                              "total": Object {
+                                                                "btc": "0",
+                                                                "eth": "0",
+                                                                "usd": "0",
+                                                              },
+                                                            },
                                                             "nahmiiAvailable": Object {
                                                               "assets": Array [],
                                                               "error": true,
@@ -23924,6 +26788,16 @@ ShallowWrapper {
                                                               },
                                                             },
                                                             "combined": Object {
+                                                              "assets": Array [],
+                                                              "error": null,
+                                                              "loading": true,
+                                                              "total": Object {
+                                                                "btc": "0",
+                                                                "eth": "0",
+                                                                "usd": "0",
+                                                              },
+                                                            },
+                                                            "nahmiiActive": Object {
                                                               "assets": Array [],
                                                               "error": null,
                                                               "loading": true,
@@ -24001,6 +26875,16 @@ ShallowWrapper {
                                                               "assets": Array [],
                                                               "error": null,
                                                               "loading": true,
+                                                              "total": Object {
+                                                                "btc": "0",
+                                                                "eth": "0",
+                                                                "usd": "0",
+                                                              },
+                                                            },
+                                                            "nahmiiActive": Object {
+                                                              "assets": Array [],
+                                                              "error": null,
+                                                              "loading": false,
                                                               "total": Object {
                                                                 "btc": "0",
                                                                 "eth": "0",
@@ -24145,6 +27029,15 @@ ShallowWrapper {
                                                                                     },
                                                                                     loading: false,
                                                                                     error: true,
+                                                                                    total: Immutable.Map {
+                                                                                                  usd: "0",
+                                                                                    },
+                                                                      },
+                                                                      nahmiiActive: Immutable.Map {
+                                                                                    assets: Immutable.Map {
+                                                                                    },
+                                                                                    loading: false,
+                                                                                    error: null,
                                                                                     total: Immutable.Map {
                                                                                                   usd: "0",
                                                                                     },
@@ -24337,6 +27230,37 @@ ShallowWrapper {
                                                               "usd": "164.492044000001231288",
                                                             },
                                                           },
+                                                          "nahmiiActive": Object {
+                                                            "assets": Array [
+                                                              Object {
+                                                                "balance": "0.2",
+                                                                "currency": "0x0000000000000000000000000000000000000000",
+                                                                "symbol": "ETH",
+                                                                "value": Object {
+                                                                  "btc": "0.002",
+                                                                  "eth": "0.2",
+                                                                  "usd": "82.4",
+                                                                },
+                                                              },
+                                                              Object {
+                                                                "balance": "0.13",
+                                                                "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                "symbol": "BOKKY",
+                                                                "value": Object {
+                                                                  "btc": "0.00013",
+                                                                  "eth": "0.013",
+                                                                  "usd": "0.13",
+                                                                },
+                                                              },
+                                                            ],
+                                                            "error": null,
+                                                            "loading": false,
+                                                            "total": Object {
+                                                              "btc": "0.00213",
+                                                              "eth": "0.213",
+                                                              "usd": "82.53",
+                                                            },
+                                                          },
                                                           "nahmiiAvailable": Object {
                                                             "assets": Array [
                                                               Object {
@@ -24459,6 +27383,16 @@ ShallowWrapper {
                                                               "usd": "0",
                                                             },
                                                           },
+                                                          "nahmiiActive": Object {
+                                                            "assets": Array [],
+                                                            "error": true,
+                                                            "loading": false,
+                                                            "total": Object {
+                                                              "btc": "0",
+                                                              "eth": "0",
+                                                              "usd": "0",
+                                                            },
+                                                          },
                                                           "nahmiiAvailable": Object {
                                                             "assets": Array [],
                                                             "error": true,
@@ -24518,6 +27452,16 @@ ShallowWrapper {
                                                             },
                                                           },
                                                           "combined": Object {
+                                                            "assets": Array [],
+                                                            "error": null,
+                                                            "loading": true,
+                                                            "total": Object {
+                                                              "btc": "0",
+                                                              "eth": "0",
+                                                              "usd": "0",
+                                                            },
+                                                          },
+                                                          "nahmiiActive": Object {
                                                             "assets": Array [],
                                                             "error": null,
                                                             "loading": true,
@@ -24595,6 +27539,16 @@ ShallowWrapper {
                                                             "assets": Array [],
                                                             "error": null,
                                                             "loading": true,
+                                                            "total": Object {
+                                                              "btc": "0",
+                                                              "eth": "0",
+                                                              "usd": "0",
+                                                            },
+                                                          },
+                                                          "nahmiiActive": Object {
+                                                            "assets": Array [],
+                                                            "error": null,
+                                                            "loading": false,
                                                             "total": Object {
                                                               "btc": "0",
                                                               "eth": "0",
@@ -24813,6 +27767,37 @@ ShallowWrapper {
                             "usd": "164.492044000001231288",
                           },
                         },
+                        "nahmiiActive": Object {
+                          "assets": Array [
+                            Object {
+                              "balance": "0.2",
+                              "currency": "0x0000000000000000000000000000000000000000",
+                              "symbol": "ETH",
+                              "value": Object {
+                                "btc": "0.002",
+                                "eth": "0.2",
+                                "usd": "82.4",
+                              },
+                            },
+                            Object {
+                              "balance": "0.13",
+                              "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                              "symbol": "BOKKY",
+                              "value": Object {
+                                "btc": "0.00013",
+                                "eth": "0.013",
+                                "usd": "0.13",
+                              },
+                            },
+                          ],
+                          "error": null,
+                          "loading": false,
+                          "total": Object {
+                            "btc": "0.00213",
+                            "eth": "0.213",
+                            "usd": "82.53",
+                          },
+                        },
                         "nahmiiAvailable": Object {
                           "assets": Array [
                             Object {
@@ -24935,6 +27920,16 @@ ShallowWrapper {
                             "usd": "0",
                           },
                         },
+                        "nahmiiActive": Object {
+                          "assets": Array [],
+                          "error": true,
+                          "loading": false,
+                          "total": Object {
+                            "btc": "0",
+                            "eth": "0",
+                            "usd": "0",
+                          },
+                        },
                         "nahmiiAvailable": Object {
                           "assets": Array [],
                           "error": true,
@@ -24994,6 +27989,16 @@ ShallowWrapper {
                           },
                         },
                         "combined": Object {
+                          "assets": Array [],
+                          "error": null,
+                          "loading": true,
+                          "total": Object {
+                            "btc": "0",
+                            "eth": "0",
+                            "usd": "0",
+                          },
+                        },
+                        "nahmiiActive": Object {
                           "assets": Array [],
                           "error": null,
                           "loading": true,
@@ -25071,6 +28076,16 @@ ShallowWrapper {
                           "assets": Array [],
                           "error": null,
                           "loading": true,
+                          "total": Object {
+                            "btc": "0",
+                            "eth": "0",
+                            "usd": "0",
+                          },
+                        },
+                        "nahmiiActive": Object {
+                          "assets": Array [],
+                          "error": null,
+                          "loading": false,
                           "total": Object {
                             "btc": "0",
                             "eth": "0",
@@ -25224,6 +28239,15 @@ ShallowWrapper {
                                                                                                 usd: "0",
                                                                                 },
                                                                 },
+                                                                nahmiiActive: Immutable.Map {
+                                                                                assets: Immutable.Map {
+                                                                                },
+                                                                                loading: false,
+                                                                                error: null,
+                                                                                total: Immutable.Map {
+                                                                                                usd: "0",
+                                                                                },
+                                                                },
                                                                 nahmiiCombined: Immutable.Map {
                                                                                 assets: Immutable.Map {
                                                                                 },
@@ -25339,6 +28363,15 @@ ShallowWrapper {
                                                                                 },
                                                                                 loading: false,
                                                                                 error: true,
+                                                                                total: Immutable.Map {
+                                                                                                    usd: "0",
+                                                                                },
+                                                            },
+                                                            nahmiiActive: Immutable.Map {
+                                                                                assets: Immutable.Map {
+                                                                                },
+                                                                                loading: false,
+                                                                                error: null,
                                                                                 total: Immutable.Map {
                                                                                                     usd: "0",
                                                                                 },
@@ -25459,6 +28492,15 @@ ShallowWrapper {
                                             },
                                             loading: false,
                                             error: true,
+                                            total: Immutable.Map {
+                                                                  usd: "0",
+                                            },
+                      },
+                      nahmiiActive: Immutable.Map {
+                                            assets: Immutable.Map {
+                                            },
+                                            loading: false,
+                                            error: null,
                                             total: Immutable.Map {
                                                                   usd: "0",
                                             },
@@ -25668,6 +28710,15 @@ ShallowWrapper {
                     usd: "0",
                 },
             },
+            nahmiiActive: Immutable.Map {
+                assets: Immutable.Map {
+                },
+                loading: false,
+                error: null,
+                total: Immutable.Map {
+                    usd: "0",
+                },
+            },
             nahmiiCombined: Immutable.Map {
                 assets: Immutable.Map {
                 },
@@ -25863,6 +28914,37 @@ ShallowWrapper {
                             usd: "82.53",
                         },
                     },
+                    nahmiiActive: Immutable.Map {
+                        loading: false,
+                        error: null,
+                        assets: Immutable.List [
+                            Immutable.Map {
+                                currency: "0x0000000000000000000000000000000000000000",
+                                balance: "0.2",
+                                symbol: "ETH",
+                                value: Immutable.Map {
+                                    eth: "0.2",
+                                    btc: "0.002",
+                                    usd: "82.4",
+                                },
+                            },
+                            Immutable.Map {
+                                currency: "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                balance: "0.13",
+                                symbol: "BOKKY",
+                                value: Immutable.Map {
+                                    eth: "0.013",
+                                    btc: "0.00013",
+                                    usd: "0.13",
+                                },
+                            },
+                        ],
+                        total: Immutable.Map {
+                            eth: "0.213",
+                            btc: "0.00213",
+                            usd: "82.53",
+                        },
+                    },
                     combined: Immutable.Map {
                         loading: false,
                         error: null,
@@ -25957,6 +29039,17 @@ ShallowWrapper {
                             usd: "0",
                         },
                     },
+                    nahmiiActive: Immutable.Map {
+                        loading: false,
+                        error: true,
+                        assets: Immutable.List [
+                        ],
+                        total: Immutable.Map {
+                            eth: "0",
+                            btc: "0",
+                            usd: "0",
+                        },
+                    },
                     combined: Immutable.Map {
                         loading: false,
                         error: true,
@@ -26037,6 +29130,17 @@ ShallowWrapper {
                             usd: "0",
                         },
                     },
+                    nahmiiActive: Immutable.Map {
+                        loading: true,
+                        error: null,
+                        assets: Immutable.List [
+                        ],
+                        total: Immutable.Map {
+                            eth: "0",
+                            btc: "0",
+                            usd: "0",
+                        },
+                    },
                     combined: Immutable.Map {
                         loading: true,
                         error: null,
@@ -26102,6 +29206,17 @@ ShallowWrapper {
                         },
                     },
                     nahmiiCombined: Immutable.Map {
+                        loading: false,
+                        error: null,
+                        assets: Immutable.List [
+                        ],
+                        total: Immutable.Map {
+                            eth: "0",
+                            btc: "0",
+                            usd: "0",
+                        },
+                    },
+                    nahmiiActive: Immutable.Map {
                         loading: false,
                         error: null,
                         assets: Immutable.List [
@@ -26304,6 +29419,37 @@ ShallowWrapper {
                                                 "usd": "164.492044000001231288",
                                               },
                                             },
+                                            "nahmiiActive": Object {
+                                              "assets": Array [
+                                                Object {
+                                                  "balance": "0.2",
+                                                  "currency": "0x0000000000000000000000000000000000000000",
+                                                  "symbol": "ETH",
+                                                  "value": Object {
+                                                    "btc": "0.002",
+                                                    "eth": "0.2",
+                                                    "usd": "82.4",
+                                                  },
+                                                },
+                                                Object {
+                                                  "balance": "0.13",
+                                                  "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                  "symbol": "BOKKY",
+                                                  "value": Object {
+                                                    "btc": "0.00013",
+                                                    "eth": "0.013",
+                                                    "usd": "0.13",
+                                                  },
+                                                },
+                                              ],
+                                              "error": null,
+                                              "loading": false,
+                                              "total": Object {
+                                                "btc": "0.00213",
+                                                "eth": "0.213",
+                                                "usd": "82.53",
+                                              },
+                                            },
                                             "nahmiiAvailable": Object {
                                               "assets": Array [
                                                 Object {
@@ -26426,6 +29572,16 @@ ShallowWrapper {
                                                 "usd": "0",
                                               },
                                             },
+                                            "nahmiiActive": Object {
+                                              "assets": Array [],
+                                              "error": true,
+                                              "loading": false,
+                                              "total": Object {
+                                                "btc": "0",
+                                                "eth": "0",
+                                                "usd": "0",
+                                              },
+                                            },
                                             "nahmiiAvailable": Object {
                                               "assets": Array [],
                                               "error": true,
@@ -26485,6 +29641,16 @@ ShallowWrapper {
                                               },
                                             },
                                             "combined": Object {
+                                              "assets": Array [],
+                                              "error": null,
+                                              "loading": true,
+                                              "total": Object {
+                                                "btc": "0",
+                                                "eth": "0",
+                                                "usd": "0",
+                                              },
+                                            },
+                                            "nahmiiActive": Object {
                                               "assets": Array [],
                                               "error": null,
                                               "loading": true,
@@ -26562,6 +29728,16 @@ ShallowWrapper {
                                               "assets": Array [],
                                               "error": null,
                                               "loading": true,
+                                              "total": Object {
+                                                "btc": "0",
+                                                "eth": "0",
+                                                "usd": "0",
+                                              },
+                                            },
+                                            "nahmiiActive": Object {
+                                              "assets": Array [],
+                                              "error": null,
+                                              "loading": false,
                                               "total": Object {
                                                 "btc": "0",
                                                 "eth": "0",
@@ -26705,6 +29881,15 @@ ShallowWrapper {
                                                         assets: Immutable.Map {
                                                         },
                                                         loading: true,
+                                                        error: null,
+                                                        total: Immutable.Map {
+                                                                usd: "0",
+                                                        },
+                                                },
+                                                nahmiiActive: Immutable.Map {
+                                                        assets: Immutable.Map {
+                                                        },
+                                                        loading: false,
                                                         error: null,
                                                         total: Immutable.Map {
                                                                 usd: "0",
@@ -26898,6 +30083,37 @@ ShallowWrapper {
                                                         "usd": "164.492044000001231288",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [
+                                                        Object {
+                                                          "balance": "0.2",
+                                                          "currency": "0x0000000000000000000000000000000000000000",
+                                                          "symbol": "ETH",
+                                                          "value": Object {
+                                                            "btc": "0.002",
+                                                            "eth": "0.2",
+                                                            "usd": "82.4",
+                                                          },
+                                                        },
+                                                        Object {
+                                                          "balance": "0.13",
+                                                          "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                          "symbol": "BOKKY",
+                                                          "value": Object {
+                                                            "btc": "0.00013",
+                                                            "eth": "0.013",
+                                                            "usd": "0.13",
+                                                          },
+                                                        },
+                                                      ],
+                                                      "error": null,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0.00213",
+                                                        "eth": "0.213",
+                                                        "usd": "82.53",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [
                                                         Object {
@@ -27020,6 +30236,16 @@ ShallowWrapper {
                                                         "usd": "0",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": true,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [],
                                                       "error": true,
@@ -27079,6 +30305,16 @@ ShallowWrapper {
                                                       },
                                                     },
                                                     "combined": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
@@ -27156,6 +30392,16 @@ ShallowWrapper {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": false,
                                                       "total": Object {
                                                         "btc": "0",
                                                         "eth": "0",
@@ -27299,6 +30545,15 @@ ShallowWrapper {
                                                                         assets: Immutable.Map {
                                                                         },
                                                                         loading: true,
+                                                                        error: null,
+                                                                        total: Immutable.Map {
+                                                                                    usd: "0",
+                                                                        },
+                                                            },
+                                                            nahmiiActive: Immutable.Map {
+                                                                        assets: Immutable.Map {
+                                                                        },
+                                                                        loading: false,
                                                                         error: null,
                                                                         total: Immutable.Map {
                                                                                     usd: "0",
@@ -27492,6 +30747,37 @@ ShallowWrapper {
                                                         "usd": "164.492044000001231288",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [
+                                                        Object {
+                                                          "balance": "0.2",
+                                                          "currency": "0x0000000000000000000000000000000000000000",
+                                                          "symbol": "ETH",
+                                                          "value": Object {
+                                                            "btc": "0.002",
+                                                            "eth": "0.2",
+                                                            "usd": "82.4",
+                                                          },
+                                                        },
+                                                        Object {
+                                                          "balance": "0.13",
+                                                          "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                          "symbol": "BOKKY",
+                                                          "value": Object {
+                                                            "btc": "0.00013",
+                                                            "eth": "0.013",
+                                                            "usd": "0.13",
+                                                          },
+                                                        },
+                                                      ],
+                                                      "error": null,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0.00213",
+                                                        "eth": "0.213",
+                                                        "usd": "82.53",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [
                                                         Object {
@@ -27614,6 +30900,16 @@ ShallowWrapper {
                                                         "usd": "0",
                                                       },
                                                     },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": true,
+                                                      "loading": false,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
                                                     "nahmiiAvailable": Object {
                                                       "assets": Array [],
                                                       "error": true,
@@ -27673,6 +30969,16 @@ ShallowWrapper {
                                                       },
                                                     },
                                                     "combined": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
@@ -27750,6 +31056,16 @@ ShallowWrapper {
                                                       "assets": Array [],
                                                       "error": null,
                                                       "loading": true,
+                                                      "total": Object {
+                                                        "btc": "0",
+                                                        "eth": "0",
+                                                        "usd": "0",
+                                                      },
+                                                    },
+                                                    "nahmiiActive": Object {
+                                                      "assets": Array [],
+                                                      "error": null,
+                                                      "loading": false,
                                                       "total": Object {
                                                         "btc": "0",
                                                         "eth": "0",
@@ -27968,6 +31284,37 @@ ShallowWrapper {
                           "usd": "164.492044000001231288",
                         },
                       },
+                      "nahmiiActive": Object {
+                        "assets": Array [
+                          Object {
+                            "balance": "0.2",
+                            "currency": "0x0000000000000000000000000000000000000000",
+                            "symbol": "ETH",
+                            "value": Object {
+                              "btc": "0.002",
+                              "eth": "0.2",
+                              "usd": "82.4",
+                            },
+                          },
+                          Object {
+                            "balance": "0.13",
+                            "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                            "symbol": "BOKKY",
+                            "value": Object {
+                              "btc": "0.00013",
+                              "eth": "0.013",
+                              "usd": "0.13",
+                            },
+                          },
+                        ],
+                        "error": null,
+                        "loading": false,
+                        "total": Object {
+                          "btc": "0.00213",
+                          "eth": "0.213",
+                          "usd": "82.53",
+                        },
+                      },
                       "nahmiiAvailable": Object {
                         "assets": Array [
                           Object {
@@ -28090,6 +31437,16 @@ ShallowWrapper {
                           "usd": "0",
                         },
                       },
+                      "nahmiiActive": Object {
+                        "assets": Array [],
+                        "error": true,
+                        "loading": false,
+                        "total": Object {
+                          "btc": "0",
+                          "eth": "0",
+                          "usd": "0",
+                        },
+                      },
                       "nahmiiAvailable": Object {
                         "assets": Array [],
                         "error": true,
@@ -28149,6 +31506,16 @@ ShallowWrapper {
                         },
                       },
                       "combined": Object {
+                        "assets": Array [],
+                        "error": null,
+                        "loading": true,
+                        "total": Object {
+                          "btc": "0",
+                          "eth": "0",
+                          "usd": "0",
+                        },
+                      },
+                      "nahmiiActive": Object {
                         "assets": Array [],
                         "error": null,
                         "loading": true,
@@ -28226,6 +31593,16 @@ ShallowWrapper {
                         "assets": Array [],
                         "error": null,
                         "loading": true,
+                        "total": Object {
+                          "btc": "0",
+                          "eth": "0",
+                          "usd": "0",
+                        },
+                      },
+                      "nahmiiActive": Object {
+                        "assets": Array [],
+                        "error": null,
+                        "loading": false,
                         "total": Object {
                           "btc": "0",
                           "eth": "0",
@@ -28379,6 +31756,15 @@ ShallowWrapper {
                                                                                     usd: "0",
                                                                       },
                                                         },
+                                                        nahmiiActive: Immutable.Map {
+                                                                      assets: Immutable.Map {
+                                                                      },
+                                                                      loading: false,
+                                                                      error: null,
+                                                                      total: Immutable.Map {
+                                                                                    usd: "0",
+                                                                      },
+                                                        },
                                                         nahmiiCombined: Immutable.Map {
                                                                       assets: Immutable.Map {
                                                                       },
@@ -28493,6 +31879,15 @@ ShallowWrapper {
                                                                         assets: Immutable.Map {
                                                                         },
                                                                         loading: true,
+                                                                        error: null,
+                                                                        total: Immutable.Map {
+                                                                                          usd: "0",
+                                                                        },
+                                                      },
+                                                      nahmiiActive: Immutable.Map {
+                                                                        assets: Immutable.Map {
+                                                                        },
+                                                                        loading: false,
                                                                         error: null,
                                                                         total: Immutable.Map {
                                                                                           usd: "0",
@@ -28613,6 +32008,15 @@ ShallowWrapper {
                                         assets: Immutable.Map {
                                         },
                                         loading: true,
+                                        error: null,
+                                        total: Immutable.Map {
+                                                            usd: "0",
+                                        },
+                    },
+                    nahmiiActive: Immutable.Map {
+                                        assets: Immutable.Map {
+                                        },
+                                        loading: false,
                                         error: null,
                                         total: Immutable.Map {
                                                             usd: "0",
@@ -28822,6 +32226,37 @@ ShallowWrapper {
                                                           "usd": "164.492044000001231288",
                                                         },
                                                       },
+                                                      "nahmiiActive": Object {
+                                                        "assets": Array [
+                                                          Object {
+                                                            "balance": "0.2",
+                                                            "currency": "0x0000000000000000000000000000000000000000",
+                                                            "symbol": "ETH",
+                                                            "value": Object {
+                                                              "btc": "0.002",
+                                                              "eth": "0.2",
+                                                              "usd": "82.4",
+                                                            },
+                                                          },
+                                                          Object {
+                                                            "balance": "0.13",
+                                                            "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                            "symbol": "BOKKY",
+                                                            "value": Object {
+                                                              "btc": "0.00013",
+                                                              "eth": "0.013",
+                                                              "usd": "0.13",
+                                                            },
+                                                          },
+                                                        ],
+                                                        "error": null,
+                                                        "loading": false,
+                                                        "total": Object {
+                                                          "btc": "0.00213",
+                                                          "eth": "0.213",
+                                                          "usd": "82.53",
+                                                        },
+                                                      },
                                                       "nahmiiAvailable": Object {
                                                         "assets": Array [
                                                           Object {
@@ -28944,6 +32379,16 @@ ShallowWrapper {
                                                           "usd": "0",
                                                         },
                                                       },
+                                                      "nahmiiActive": Object {
+                                                        "assets": Array [],
+                                                        "error": true,
+                                                        "loading": false,
+                                                        "total": Object {
+                                                          "btc": "0",
+                                                          "eth": "0",
+                                                          "usd": "0",
+                                                        },
+                                                      },
                                                       "nahmiiAvailable": Object {
                                                         "assets": Array [],
                                                         "error": true,
@@ -29003,6 +32448,16 @@ ShallowWrapper {
                                                         },
                                                       },
                                                       "combined": Object {
+                                                        "assets": Array [],
+                                                        "error": null,
+                                                        "loading": true,
+                                                        "total": Object {
+                                                          "btc": "0",
+                                                          "eth": "0",
+                                                          "usd": "0",
+                                                        },
+                                                      },
+                                                      "nahmiiActive": Object {
                                                         "assets": Array [],
                                                         "error": null,
                                                         "loading": true,
@@ -29080,6 +32535,16 @@ ShallowWrapper {
                                                         "assets": Array [],
                                                         "error": null,
                                                         "loading": true,
+                                                        "total": Object {
+                                                          "btc": "0",
+                                                          "eth": "0",
+                                                          "usd": "0",
+                                                        },
+                                                      },
+                                                      "nahmiiActive": Object {
+                                                        "assets": Array [],
+                                                        "error": null,
+                                                        "loading": false,
                                                         "total": Object {
                                                           "btc": "0",
                                                           "eth": "0",
@@ -29223,6 +32688,15 @@ ShallowWrapper {
                                                                       assets: Immutable.Map {
                                                                       },
                                                                       loading: true,
+                                                                      error: null,
+                                                                      total: Immutable.Map {
+                                                                                usd: "0",
+                                                                      },
+                                                            },
+                                                            nahmiiActive: Immutable.Map {
+                                                                      assets: Immutable.Map {
+                                                                      },
+                                                                      loading: false,
                                                                       error: null,
                                                                       total: Immutable.Map {
                                                                                 usd: "0",
@@ -29416,6 +32890,37 @@ ShallowWrapper {
                                                                 "usd": "164.492044000001231288",
                                                               },
                                                             },
+                                                            "nahmiiActive": Object {
+                                                              "assets": Array [
+                                                                Object {
+                                                                  "balance": "0.2",
+                                                                  "currency": "0x0000000000000000000000000000000000000000",
+                                                                  "symbol": "ETH",
+                                                                  "value": Object {
+                                                                    "btc": "0.002",
+                                                                    "eth": "0.2",
+                                                                    "usd": "82.4",
+                                                                  },
+                                                                },
+                                                                Object {
+                                                                  "balance": "0.13",
+                                                                  "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                  "symbol": "BOKKY",
+                                                                  "value": Object {
+                                                                    "btc": "0.00013",
+                                                                    "eth": "0.013",
+                                                                    "usd": "0.13",
+                                                                  },
+                                                                },
+                                                              ],
+                                                              "error": null,
+                                                              "loading": false,
+                                                              "total": Object {
+                                                                "btc": "0.00213",
+                                                                "eth": "0.213",
+                                                                "usd": "82.53",
+                                                              },
+                                                            },
                                                             "nahmiiAvailable": Object {
                                                               "assets": Array [
                                                                 Object {
@@ -29538,6 +33043,16 @@ ShallowWrapper {
                                                                 "usd": "0",
                                                               },
                                                             },
+                                                            "nahmiiActive": Object {
+                                                              "assets": Array [],
+                                                              "error": true,
+                                                              "loading": false,
+                                                              "total": Object {
+                                                                "btc": "0",
+                                                                "eth": "0",
+                                                                "usd": "0",
+                                                              },
+                                                            },
                                                             "nahmiiAvailable": Object {
                                                               "assets": Array [],
                                                               "error": true,
@@ -29597,6 +33112,16 @@ ShallowWrapper {
                                                               },
                                                             },
                                                             "combined": Object {
+                                                              "assets": Array [],
+                                                              "error": null,
+                                                              "loading": true,
+                                                              "total": Object {
+                                                                "btc": "0",
+                                                                "eth": "0",
+                                                                "usd": "0",
+                                                              },
+                                                            },
+                                                            "nahmiiActive": Object {
                                                               "assets": Array [],
                                                               "error": null,
                                                               "loading": true,
@@ -29674,6 +33199,16 @@ ShallowWrapper {
                                                               "assets": Array [],
                                                               "error": null,
                                                               "loading": true,
+                                                              "total": Object {
+                                                                "btc": "0",
+                                                                "eth": "0",
+                                                                "usd": "0",
+                                                              },
+                                                            },
+                                                            "nahmiiActive": Object {
+                                                              "assets": Array [],
+                                                              "error": null,
+                                                              "loading": false,
                                                               "total": Object {
                                                                 "btc": "0",
                                                                 "eth": "0",
@@ -29817,6 +33352,15 @@ ShallowWrapper {
                                                                                     assets: Immutable.Map {
                                                                                     },
                                                                                     loading: true,
+                                                                                    error: null,
+                                                                                    total: Immutable.Map {
+                                                                                                  usd: "0",
+                                                                                    },
+                                                                      },
+                                                                      nahmiiActive: Immutable.Map {
+                                                                                    assets: Immutable.Map {
+                                                                                    },
+                                                                                    loading: false,
                                                                                     error: null,
                                                                                     total: Immutable.Map {
                                                                                                   usd: "0",
@@ -30010,6 +33554,37 @@ ShallowWrapper {
                                                               "usd": "164.492044000001231288",
                                                             },
                                                           },
+                                                          "nahmiiActive": Object {
+                                                            "assets": Array [
+                                                              Object {
+                                                                "balance": "0.2",
+                                                                "currency": "0x0000000000000000000000000000000000000000",
+                                                                "symbol": "ETH",
+                                                                "value": Object {
+                                                                  "btc": "0.002",
+                                                                  "eth": "0.2",
+                                                                  "usd": "82.4",
+                                                                },
+                                                              },
+                                                              Object {
+                                                                "balance": "0.13",
+                                                                "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                                                                "symbol": "BOKKY",
+                                                                "value": Object {
+                                                                  "btc": "0.00013",
+                                                                  "eth": "0.013",
+                                                                  "usd": "0.13",
+                                                                },
+                                                              },
+                                                            ],
+                                                            "error": null,
+                                                            "loading": false,
+                                                            "total": Object {
+                                                              "btc": "0.00213",
+                                                              "eth": "0.213",
+                                                              "usd": "82.53",
+                                                            },
+                                                          },
                                                           "nahmiiAvailable": Object {
                                                             "assets": Array [
                                                               Object {
@@ -30132,6 +33707,16 @@ ShallowWrapper {
                                                               "usd": "0",
                                                             },
                                                           },
+                                                          "nahmiiActive": Object {
+                                                            "assets": Array [],
+                                                            "error": true,
+                                                            "loading": false,
+                                                            "total": Object {
+                                                              "btc": "0",
+                                                              "eth": "0",
+                                                              "usd": "0",
+                                                            },
+                                                          },
                                                           "nahmiiAvailable": Object {
                                                             "assets": Array [],
                                                             "error": true,
@@ -30191,6 +33776,16 @@ ShallowWrapper {
                                                             },
                                                           },
                                                           "combined": Object {
+                                                            "assets": Array [],
+                                                            "error": null,
+                                                            "loading": true,
+                                                            "total": Object {
+                                                              "btc": "0",
+                                                              "eth": "0",
+                                                              "usd": "0",
+                                                            },
+                                                          },
+                                                          "nahmiiActive": Object {
                                                             "assets": Array [],
                                                             "error": null,
                                                             "loading": true,
@@ -30268,6 +33863,16 @@ ShallowWrapper {
                                                             "assets": Array [],
                                                             "error": null,
                                                             "loading": true,
+                                                            "total": Object {
+                                                              "btc": "0",
+                                                              "eth": "0",
+                                                              "usd": "0",
+                                                            },
+                                                          },
+                                                          "nahmiiActive": Object {
+                                                            "assets": Array [],
+                                                            "error": null,
+                                                            "loading": false,
                                                             "total": Object {
                                                               "btc": "0",
                                                               "eth": "0",
@@ -30486,6 +34091,37 @@ ShallowWrapper {
                             "usd": "164.492044000001231288",
                           },
                         },
+                        "nahmiiActive": Object {
+                          "assets": Array [
+                            Object {
+                              "balance": "0.2",
+                              "currency": "0x0000000000000000000000000000000000000000",
+                              "symbol": "ETH",
+                              "value": Object {
+                                "btc": "0.002",
+                                "eth": "0.2",
+                                "usd": "82.4",
+                              },
+                            },
+                            Object {
+                              "balance": "0.13",
+                              "currency": "0x583cbbb8a8443b38abcc0c956bece47340ea1367",
+                              "symbol": "BOKKY",
+                              "value": Object {
+                                "btc": "0.00013",
+                                "eth": "0.013",
+                                "usd": "0.13",
+                              },
+                            },
+                          ],
+                          "error": null,
+                          "loading": false,
+                          "total": Object {
+                            "btc": "0.00213",
+                            "eth": "0.213",
+                            "usd": "82.53",
+                          },
+                        },
                         "nahmiiAvailable": Object {
                           "assets": Array [
                             Object {
@@ -30608,6 +34244,16 @@ ShallowWrapper {
                             "usd": "0",
                           },
                         },
+                        "nahmiiActive": Object {
+                          "assets": Array [],
+                          "error": true,
+                          "loading": false,
+                          "total": Object {
+                            "btc": "0",
+                            "eth": "0",
+                            "usd": "0",
+                          },
+                        },
                         "nahmiiAvailable": Object {
                           "assets": Array [],
                           "error": true,
@@ -30667,6 +34313,16 @@ ShallowWrapper {
                           },
                         },
                         "combined": Object {
+                          "assets": Array [],
+                          "error": null,
+                          "loading": true,
+                          "total": Object {
+                            "btc": "0",
+                            "eth": "0",
+                            "usd": "0",
+                          },
+                        },
+                        "nahmiiActive": Object {
                           "assets": Array [],
                           "error": null,
                           "loading": true,
@@ -30744,6 +34400,16 @@ ShallowWrapper {
                           "assets": Array [],
                           "error": null,
                           "loading": true,
+                          "total": Object {
+                            "btc": "0",
+                            "eth": "0",
+                            "usd": "0",
+                          },
+                        },
+                        "nahmiiActive": Object {
+                          "assets": Array [],
+                          "error": null,
+                          "loading": false,
                           "total": Object {
                             "btc": "0",
                             "eth": "0",
@@ -30897,6 +34563,15 @@ ShallowWrapper {
                                                                                                 usd: "0",
                                                                                 },
                                                                 },
+                                                                nahmiiActive: Immutable.Map {
+                                                                                assets: Immutable.Map {
+                                                                                },
+                                                                                loading: false,
+                                                                                error: null,
+                                                                                total: Immutable.Map {
+                                                                                                usd: "0",
+                                                                                },
+                                                                },
                                                                 nahmiiCombined: Immutable.Map {
                                                                                 assets: Immutable.Map {
                                                                                 },
@@ -31011,6 +34686,15 @@ ShallowWrapper {
                                                                                 assets: Immutable.Map {
                                                                                 },
                                                                                 loading: true,
+                                                                                error: null,
+                                                                                total: Immutable.Map {
+                                                                                                    usd: "0",
+                                                                                },
+                                                            },
+                                                            nahmiiActive: Immutable.Map {
+                                                                                assets: Immutable.Map {
+                                                                                },
+                                                                                loading: false,
                                                                                 error: null,
                                                                                 total: Immutable.Map {
                                                                                                     usd: "0",
@@ -31131,6 +34815,15 @@ ShallowWrapper {
                                             assets: Immutable.Map {
                                             },
                                             loading: true,
+                                            error: null,
+                                            total: Immutable.Map {
+                                                                  usd: "0",
+                                            },
+                      },
+                      nahmiiActive: Immutable.Map {
+                                            assets: Immutable.Map {
+                                            },
+                                            loading: false,
                                             error: null,
                                             total: Immutable.Map {
                                                                   usd: "0",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -290,7 +290,7 @@
     "waiting_for_withdraw_to_be": "Waiting for transaction to be",
     "nahmii_staged": "nahmii staged",
     "withdraw_exceeded_staged_amount": "Settlement needed",
-    "why_settlement_notes": "Currently the maximum immediate withdrawable amount(staged amount) is {staged_amount} {symbol}. In order to withdraw {withdraw_amount} {symbol}, it requires additional {required_stage_amout} {symbol} from nahmii balance to go through a settlement process. Once the settlement is started, the intended stage amount will be subtracted from the nahmii available balance, and will be added to the staged balance after the settlement is qualified.",
+    "why_settlement_notes": "Currently the maximum immediately withdrawable amount (staged amount) is {staged_amount} {symbol}. In order to withdraw {withdraw_amount} {symbol}, it requires an additional {required_stage_amout} {symbol} from nahmii balance to go through a settlement process. Once the settlement is started the intended stage amount will be subtracted from the nahmii available balance for it to be added to the staged balance after the settlement is qualified.",
     "intended_stage_amount": "{amount} {symbol}",
     "expiration_time": "Until {endtime}",
     "withdrawable_amount": "{amount} {symbol}",


### PR DESCRIPTION
 - Add nahmiiActive balances in selector to account for available and staging balances
 - Update nahmiiCombined balances in selector to account for all balances including staged ones
 - Update withdrawal view to use nahmiiCombined instead
 - Balance breakdowns use nahmiiActive to avoid wrong balances amount during a certain period when staging a qualified settlement.